### PR TITLE
Add CI Build system for Zoo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Zoo CI
+
+on:
+  push:
+    branches:
+      - main
+      - ci-clean
+  pull_request:
+    branches:
+      - main
+      - ci-clean
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Build Docker image
+        run: docker build -t zoo-ci .
+
+      - name: Run Coq build (default zoo)
+        run: docker run --rm zoo-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM coqorg/coq:8.20.1-ocaml-4.14.2-flambda
+
+USER root
+ENV DEBIAN_FRONTEND=noninteractive
+ENV OPAMYES=true
+
+# Install required packages
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+    git bubblewrap m4 unzip pkg-config libgmp-dev libev-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /root
+
+# Clone the zoo repo
+RUN git clone https://github.com/clef-men/zoo
+WORKDIR /root/zoo
+
+# Copy build script into image
+COPY make_package.sh /usr/local/bin/build-package
+RUN chmod +x /usr/local/bin/build-package
+
+# Initialize opam and set up local switch
+RUN opam init --disable-sandboxing --yes && \
+    eval $(opam env --switch=. --set-switch) && \
+    opam repo add coq-released https://coq.inria.fr/opam/released && \
+    opam repo add iris-dev git+https://gitlab.mpi-sws.org/iris/opam.git &&\
+    opam install ./coq-zoo.opam --deps-only --yes
+
+# Default command (can be overridden at runtime)
+CMD ["/usr/local/bin/build-package", "zoo"]


### PR DESCRIPTION
Add Dockerfile for CI Support

This PR introduces a Dockerfile to enable GitHub Actions-based CI for the Zoo project.

The current build time is approximately 50 minutes [example](https://github.com/durwasa-chakraborty/zoo/actions/runs/16000006077/job/45132284688). I’m currently exploring optimizations to reduce the build time, aiming for a more practical and efficient CI workflow.

If this direction doesn’t align with your current plans or priorities, please feel free to close the PR.