### PR TITLE
Packaging and instructions to build the benchmarks without Rocq

### DIFF
--- a/Makefile.lib
+++ b/Makefile.lib
@@ -1,7 +1,7 @@
 targets_nocoq += lib
 .PHONY : lib
 lib :
-	@ dune build @check @all
+	@ dune build @lib/check @lib/all
 
 targets_nocoq += ocaml2zoo
 .PHONY : ocaml2zoo

--- a/Makefile.lib
+++ b/Makefile.lib
@@ -8,6 +8,11 @@ targets_nocoq += ocaml2zoo
 ocaml2zoo :
 	@ ocaml2zoo . theories
 
+targets_nocoq += bench
+.PHONY : bench
+bench :
+	@ dune build @bench/check @bench/all
+
 .PHONY : clean
 clean ::
 	@ dune clean

--- a/README.md
+++ b/README.md
@@ -73,6 +73,31 @@ Finally, to compile Coq proofs, run:
 make -j
 ```
 
+## Building (OCaml libraries only)
+
+The repository contains the output of `ocaml2zoo` for all provided packages. If you do not wish to re-check the Coq proofs, you can build only the OCaml libraries.
+
+```
+# install the OCaml dependencies
+opam install --deps-only ./zoo*.opam
+
+# build the OCaml libraries
+make lib
+```
+
+If you want to compile and run the benchmarks, you need to invoke opam with `--with-dev-setup` to get the benchmark-only dependencies.
+
+```
+# install the OCaml development dependencies
+opam install --with-dev-setup --deps-only ./zoo*.opam
+
+# build the OCaml libraries
+make lib
+
+# build the benchmarks
+make bench
+```
+
 ## Installation
 
 Zoo is not available on `opam` yet, but you can already use it in your Coq developments by adding the following `opam` dependency:

--- a/dune-project
+++ b/dune-project
@@ -51,6 +51,10 @@
     zoo
     zoo_std
     zoo_saturn
+
+    ; benchmark dependencies
+    (domainslib :with-dev-setup)
+    (moonpool :with-dev-setup)
   )
 )
 

--- a/zoo_parabs.opam
+++ b/zoo_parabs.opam
@@ -11,6 +11,8 @@ depends: [
   "zoo"
   "zoo_std"
   "zoo_saturn"
+  "domainslib" {with-dev-setup}
+  "moonpool" {with-dev-setup}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
With the current `dev` branch, on my machine, running `make lib` fails because moonpool is not installed. (It is not listed as a dependency of any of the opam packages for zoo.)

In this PR:

- `make lib` builds only `lib/`, with a separate `make bench` target
- correct dependencies to build the benchmark as "dev-setup" dependencies of zoo_parabs.opam
- README.md documentation for the OCaml-only build path

(I have not tried running the benchmarks yet)