### PR TITLE
Algo.for: use a divide-and-conquer approach

### DIFF
--- a/bench/lib/pool.ml
+++ b/bench/lib/pool.ml
@@ -130,7 +130,7 @@ module Parabs = Make(struct
     Pool.wait
 
   let for_ ctx ~beg ~end_ ~chunk fn =
-    Algo.for_ ctx beg end_ chunk fn
+    Algo.for_2 ctx beg end_ chunk fn
 
   let divide ctx ~beg ~end_ fn =
     Algo.divide ctx beg end_ fn

--- a/lib/zoo_parabs/algo.mli
+++ b/lib/zoo_parabs/algo.mli
@@ -8,6 +8,14 @@ val for_ :
   (Pool.context -> int -> unit) ->
   unit
 
+val for_2 :
+  Pool.context ->
+  int ->
+  int ->
+  int ->
+  (Pool.context -> int -> unit) ->
+  unit
+
 val divide :
   Pool.context ->
   int ->


### PR DESCRIPTION
This PR provides an alternative implementation of `Algo.for_`. Instead of pushing `size / chunk` chunk-sized tasks, it uses a divide-and-conquer approach, inspired by the implementation in `domainslib`: first spawn only two tasks that each cover one half of the iteration size, and then each of those will in turn spawn two quarter-sized tasks, etc. 

The benefits of this approach comes from work-stealing: if domains are waiting with nothing to do, they will steal "large" tasks from the current domain instead of stealing only chunk-sized tasks, so they need much less steals to spread the computation work effectively across domains.

I have not rerun most benchmarks yet, but on `lu` (where `parabs` had unexplainedly bad performance compared to `domainslib`) I observe that Parabs is now almost as fast as Domainslib, which suggests that the difference in parallel-for implementation was the cause of the unexplained performance difference.
One would need to also re-run the other benchmarks to ensure that there is no performance regression on other benchmarks.