### PR TITLE
Standalone `Pool.run`

### DIFF
--- a/bench/fibonacci/run.ml
+++ b/bench/fibonacci/run.ml
@@ -53,6 +53,4 @@ let () =
   | pool ->
     let (module Pool) = Pool.impl_of_string pool in
     let module M = Make(Pool) in
-    let pool = Pool.create ~num_domain in
-    let _ = Pool.run pool (M.main ~cutoff input) in
-    Pool.close pool
+    Pool.run ~num_domain (M.main ~cutoff input) |> ignore

--- a/bench/fibonacci/run_no_cutoff.ml
+++ b/bench/fibonacci/run_no_cutoff.ml
@@ -25,6 +25,4 @@ let input =
 let () =
   let (module Pool) = pool in
   let module M = Make(Pool) in
-  let pool = Pool.create ~num_domain in
-  let _ = Pool.run pool (M.main input) in
-  Pool.close pool
+  Pool.run ~num_domain (M.main input) |> ignore

--- a/bench/for/run.ml
+++ b/bench/for/run.ml
@@ -28,6 +28,4 @@ let num_domain =
 let () =
   let (module Pool) = pool in
   let module M = Make(Pool) in
-  let pool = Pool.create ~num_domain in
-  let _ = Pool.run pool (M.main ?cutoff input) in
-  Pool.close pool
+  Pool.run ~num_domain (M.main ?cutoff input)

--- a/bench/for_irregular/run.ml
+++ b/bench/for_irregular/run.ml
@@ -57,6 +57,4 @@ let num_domain =
 let () =
   let (module Pool) = pool in
   let module M = Make(Pool) in
-  let pool = Pool.create ~num_domain in
-  let _ = Pool.run pool (M.main ~limit ?cutoff input) in
-  Pool.close pool
+  Pool.run ~num_domain (M.main ~limit ?cutoff input)

--- a/bench/iota/run.ml
+++ b/bench/iota/run.ml
@@ -26,6 +26,4 @@ let cutoff = Utils.get_int_param "CUTOFF"
 let () =
   let (module Pool) = pool in
   let module M = Make(Pool) in
-  let pool = Pool.create ~num_domain in
-  let _ = Pool.run pool (M.main ~size ?cutoff) in
-  Pool.close pool
+  Pool.run ~num_domain (M.main ~size ?cutoff)

--- a/bench/lib/pool.ml
+++ b/bench/lib/pool.ml
@@ -5,6 +5,12 @@ module Make
 = struct
   include Base
 
+  let run ~num_domain task =
+    let t = create ~num_domain in
+    let res = run_on t task in
+    close t ;
+    res
+
   let adjust_chunk ~beg ~end_ ~chunk ctx =
     match chunk with
     | Some chunk ->
@@ -56,7 +62,7 @@ module Sequential = Make(struct
   let create ~num_domain:_ =
     ()
 
-  let run () task =
+  let run_on () task =
     task ()
 
   let close () =
@@ -90,8 +96,8 @@ module Parabs = Make(struct
   let size =
     Pool.size
 
-  let run =
-    Pool.run
+  let run_on =
+    Pool.run_on
 
   let close =
     Pool.close
@@ -124,7 +130,7 @@ module Domainslib = Make(struct
   let size t =
     Task.get_num_domains t - 1
 
-  let run t task =
+  let run_on t task =
     Task.run t (fun () -> task t)
 
   let close =
@@ -163,7 +169,7 @@ module Moonpool_fifo_base = struct
   let size t =
     t.size
 
-  let run t task =
+  let run_on t task =
     Fifo_pool.run_wait_block t.pool (fun () -> task t)
 
   let close t =
@@ -204,7 +210,7 @@ module Moonpool_ws_base = struct
   let size t =
     t.size
 
-  let run t task =
+  let run_on t task =
     Ws_pool.run_wait_block t.pool (fun () -> task t)
 
   let close t =

--- a/bench/lib/pool_intf.ml
+++ b/bench/lib/pool_intf.ml
@@ -12,7 +12,7 @@ module type BASE = sig
   val size :
     context -> int
 
-  val run :
+  val run_on :
     t -> 'a task -> 'a
 
   val close :
@@ -29,6 +29,9 @@ end
 
 module type S = sig
   include BASE
+
+  val run :
+    num_domain:int -> 'a task -> 'a
 
   val for_ :
     beg:int -> end_:int -> ?chunk:int -> context -> (int -> int -> unit) task -> unit

--- a/bench/lu/run.ml
+++ b/bench/lu/run.ml
@@ -68,6 +68,4 @@ let cutoff =
 let () =
   let (module Pool) = pool in
   let module M = Make(Pool) in
-  let pool = Pool.create ~num_domain in
-  let _ = Pool.run pool (M.main ?cutoff size) in
-  Pool.close pool
+  Pool.run ~num_domain (M.main ?cutoff size)

--- a/bench/matmul/run.ml
+++ b/bench/matmul/run.ml
@@ -39,6 +39,4 @@ let cutoff = Utils.get_int_param "CUTOFF"
 let () =
   let (module Pool) = pool in
   let module M = Make(Pool) in
-  let pool = Pool.create ~num_domain in
-  let _ = Pool.run pool (M.main ?cutoff size) in
-  Pool.close pool
+  Pool.run ~num_domain (M.main ?cutoff size)

--- a/bench/sleeping/run.ml
+++ b/bench/sleeping/run.ml
@@ -4,18 +4,17 @@ module Make
   (Pool : Pool.S)
 = struct
   let miniwork _ctx _i =
-    Unix.sleepf (1. /. 1_000_000.); (* 1us *)
-    ()
+    Unix.sleepf (1. /. 1_000_000.) (* 1us *)
 
   let main n ctx =
     for _i = 1 to n do
       (* wake many workers up *)
       for _w = 1 to 16 do
         ignore (Pool.async ctx miniwork)
-      done;
+      done ;
       (* then they can go back to sleep *)
-      Unix.sleepf (1. /. 1000.); (* 1ms *)
-    done;
+      Unix.sleepf (1. /. 1000.) (* 1ms *)
+    done
 end
 
 let pool =
@@ -31,6 +30,4 @@ let num_domain =
 let () =
   let (module Pool) = pool in
   let module M = Make(Pool) in
-  let pool = Pool.create ~num_domain in
-  let _ = Pool.run pool (M.main input) in
-  Pool.close pool
+  Pool.run ~num_domain (M.main input)

--- a/bench/waiting/run.ml
+++ b/bench/waiting/run.ml
@@ -6,8 +6,8 @@ module Make
   let main n ctx =
     let fut = Pool.async ctx (fun _ctx -> Unix.sleepf 1.) in
     for _i = 1 to n do
-      Pool.async ctx (fun ctx -> Pool.wait ctx fut) |> ignore;
-    done;
+      Pool.async ctx (fun ctx -> Pool.wait ctx fut) |> ignore
+    done ;
     Pool.wait ctx fut
 end
 
@@ -24,6 +24,4 @@ let num_domain =
 let () =
   let (module Pool) = pool in
   let module M = Make(Pool) in
-  let pool = Pool.create ~num_domain in
-  let _ = Pool.run pool (M.main input) in
-  Pool.close pool
+  Pool.run ~num_domain (M.main input)

--- a/lib/examples/future_fibonacci.ml
+++ b/lib/examples/future_fibonacci.ml
@@ -7,7 +7,4 @@ let rec main ctx n =
     Future.wait ctx fut1 + Future.wait ctx fut2
 
 let main ~num_domain n =
-  let pool = Pool.create ~num_domain in
-  let res = Pool.run pool (fun ctx -> main ctx n) in
-  Pool.close pool ;
-  res
+  Pool.run ~num_domain (fun ctx -> main ctx n)

--- a/lib/examples/pool_counter.ml
+++ b/lib/examples/pool_counter.ml
@@ -1,10 +1,8 @@
 let main ~num_domain n =
-  let pool = Pool.create ~num_domain in
   let cnt = Atomic.make 0 in
-  Pool.run pool (fun ctx ->
+  Pool.run ~num_domain (fun ctx ->
     for _ = 0 to n - 1 do
       Pool.async ctx (fun _ctx -> Atomic.incr cnt)
     done
   ) ;
-  Pool.close pool ;
   Atomic.get cnt

--- a/lib/examples/pool_quicksort.ml
+++ b/lib/examples/pool_quicksort.ml
@@ -19,6 +19,4 @@ let main ctx arr =
   main ctx arr 0 (Array.size arr)
 
 let main ~num_domain arr =
-  let pool = Pool.create ~num_domain in
-  Pool.run pool (fun ctx -> main ctx arr) ;
-  Pool.close pool
+  Pool.run ~num_domain (fun ctx -> main ctx arr)

--- a/lib/examples/vertex_fibonacci.ml
+++ b/lib/examples/vertex_fibonacci.ml
@@ -23,21 +23,17 @@ let rec main ctx vtx r n =
   )
 
 let main ~num_domain n =
-  let pool = Pool.create ~num_domain in
-  let res =
-    Pool.run pool @@ fun ctx ->
-      let r = ref 0 in
-      let vtx1 = Vertex.create None in
-      Vertex.set_task vtx1 (fun ctx -> main ctx vtx1 r n) ;
-      Vertex.release ctx vtx1 ;
+  Pool.run ~num_domain (fun ctx ->
+    let r = ref 0 in
+    let vtx1 = Vertex.create None in
+    Vertex.set_task vtx1 (fun ctx -> main ctx vtx1 r n) ;
+    Vertex.release ctx vtx1 ;
 
-      let flag = Mpsc_flag.create () in
-      let vtx2 = Vertex.create' (fun _ctx -> Mpsc_flag.set flag) in
-      Vertex.precede vtx1 vtx2 ;
-      Vertex.release ctx vtx2 ;
+    let flag = Mpsc_flag.create () in
+    let vtx2 = Vertex.create' (fun _ctx -> Mpsc_flag.set flag) in
+    Vertex.precede vtx1 vtx2 ;
+    Vertex.release ctx vtx2 ;
 
-      Pool.wait_until ctx (fun () -> Mpsc_flag.get flag) ;
-      !r
-  in
-  Pool.close pool ;
-  res
+    Pool.wait_until ctx (fun () -> Mpsc_flag.get flag) ;
+    !r
+  )

--- a/lib/examples/vertex_simple.ml
+++ b/lib/examples/vertex_simple.ml
@@ -11,12 +11,10 @@ let main ~num_domain a b c d =
   Vertex.precede vtx_b vtx_d ;
   Vertex.precede vtx_c vtx_d ;
 
-  let pool = Pool.create ~num_domain in
-  Pool.run pool (fun ctx ->
+  Pool.run ~num_domain (fun ctx ->
     Vertex.release ctx vtx_d ;
     Vertex.release ctx vtx_c ;
     Vertex.release ctx vtx_b ;
     Vertex.release ctx vtx_a ;
     Pool.wait_until ctx (fun () -> Mpsc_flag.get flag)
-  ) ;
-  Pool.close pool
+  )

--- a/lib/zoo_parabs/pool.ml
+++ b/lib/zoo_parabs/pool.ml
@@ -55,7 +55,7 @@ let create ~num_domain:sz =
   ; force_mutable= ()
   }
 
-let run t task =
+let run_on t task =
   Ws_hub_std.unblock t.hub 0 ;
   let res = execute (context_main t) task in
   Ws_hub_std.block t.hub 0 ;
@@ -66,6 +66,12 @@ let close t =
   Ws_hub_std.unblock t.hub 0 ;
   worker (context_main t) ;
   Array.iter Domain.join t.domains
+
+let run ~num_domain task =
+  let t = create ~num_domain in
+  let res = run_on t task in
+  close t ;
+  res
 
 let size ctx =
   ctx.context_size

--- a/lib/zoo_parabs/pool.mli
+++ b/lib/zoo_parabs/pool.mli
@@ -1,7 +1,7 @@
 (** The [Pool] module exposes a low-level interface of a pool of
     worker domains on which asynchronous tasks can be scheduled.
 
-    You need to use {!create} and {!run} to start asynchronous
+    You need to use {!create} and {!run_on} to start asynchronous
     computations, and {!close} to release the worker domains at the
     end.
 
@@ -16,7 +16,7 @@
     {[
     let () =
       let pool = Pool.create ~num_domain:(Domain.recommended_domain_count () - 1) in
-      let fib40 = Pool.run pool (fun ctx -> fibo ctx 40) in
+      let fib40 = Pool.run_on pool (fun ctx -> fibo ctx 40) in
       Pool.close pool;
       fib40
     ]}
@@ -24,7 +24,7 @@
 
 type t
 (** A pool of [n] worker domains. One domain owns the pool and sends
-    toplevels tasks using the {!run} function, so in total [n+1]
+    toplevels tasks using the {!run_on} function, so in total [n+1]
     domains participate to the computation. *)
 
 type context
@@ -37,11 +37,11 @@ val create :
   num_domain:int -> t
 (** [create ~num_domain] creates a new pool with [num_domain] extra worker domains. *)
 
-val run :
+val run_on :
   t -> 'a task -> 'a
-  (** [run t task] runs a toplevel task on pool [t]; subtasks
-    will run on this (caller) domain or on the worker domains. It
-    returns when the toplevel task is finished. *)
+(** [run_on t task] runs [task] on pool [t]; subtasks will run on this
+    (caller) domain or on the worker domains. It returns when [task] is
+    finished. *)
 
 val close :
   t -> unit
@@ -49,6 +49,11 @@ val close :
     they run out of tasks, and returns when all workers are done. It
     should be called once you know that the topevel task you care
     about is finished. *)
+
+val run :
+  num_domain:int -> 'a task -> 'a
+(** [run task] creates a pool with [num_domain] extra worker domains,
+    runs [task] on it and closes the pool. *)
 
 val size :
   context -> int

--- a/theories/examples/future_fibonacci.v
+++ b/theories/examples/future_fibonacci.v
@@ -77,17 +77,15 @@ Section future_G.
     iIntros "%Φ _ HΦ".
 
     wp_rec.
-    wp_apply+ (pool_create_spec with "[//]") as (pool) "(_ & Hpool_model)". 1: lia.
 
-    wp_apply+ (pool_run_spec (λ v,
+    wp_apply+ (pool_run_spec (λ pool v,
       ⌜v = #_⌝
-    )%I with "[$Hpool_model]") as (?) "(Hpool_model & ->)".
-    { iIntros "%ctx %scope Hctx".
+    )%I) as (pool ?) "(_ & ->)". 1: lia.
+    { iIntros "%pool %ctx %scope _ Hctx".
       wp_apply+ (future_fibonacci_main_0_spec with "Hctx"); first lia.
       rewrite Nat2Z.id. iSteps.
     }
 
-    wp_apply+ (pool_close_spec with "Hpool_model").
     iSteps.
   Qed.
 End future_G.

--- a/theories/examples/future_fibonacci__code.v
+++ b/theories/examples/future_fibonacci__code.v
@@ -27,9 +27,4 @@ Definition future_fibonacci_main_0 : val :=
 
 Definition future_fibonacci_main : val :=
   fun: "num_domain" "n" =>
-    let: "pool" := pool_create "num_domain" in
-    let: "res" :=
-      pool_run "pool" (fun: "ctx" => future_fibonacci_main_0 "ctx" "n")
-    in
-    pool_close "pool" ;;
-    "res".
+    pool_run "num_domain" (fun: "ctx" => future_fibonacci_main_0 "ctx" "n").

--- a/theories/examples/pool_counter.v
+++ b/theories/examples/pool_counter.v
@@ -118,8 +118,6 @@ Section pool_counter_G.
     iIntros "%Hn %Φ _ HΦ".
 
     wp_rec.
-    wp_apply+ (pool_create_spec with "[//]") as (pool) "(_ & Hpool_model)". 1: lia.
-
     wp_ref r as "Hr".
 
     iMod (tokens_alloc n) as "(%γ & Htokens_auth & Htokens_frags)".
@@ -127,14 +125,14 @@ Section pool_counter_G.
     iDestruct (cinv_own_divide n with "Hinv_own") as "Hinv_owns". 1: lia.
     iDestruct (big_sepL_sep_2 with "Htokens_frags Hinv_owns") as "H".
 
-    wp_apply+ (pool_run_spec (λ _,
+    wp_apply+ (pool_run_spec (λ pool _,
       [∗ list] _ ∈ seq 0 n,
         pool_consumer pool (
           tokens_frag γ n 1 ∗
           cinv_own η (1 / Qp_of_nat n)
         )
-    )%I with "[$Hpool_model H]") as (?) "(Hpool_model & H)".
-    { iIntros "%ctx %scope Hctx".
+    )%I with "[H]") as (pool ?) "(#Hpool_finished & H)". 1: lia.
+    { iIntros "%pool %ctx %scope _ Hctx".
       wp_apply+ (for_spec_nat'
         (λ _ i,
           pool_context pool ctx scope ∗
@@ -171,8 +169,6 @@ Section pool_counter_G.
       iEval (rewrite Nat.sub_0_r) in "H".
       iFrame.
     }
-
-    wp_apply+ (pool_close_spec with "[$Hpool_model]") as "#Hpool_finished".
 
     iAssert (
       |={⊤}=>

--- a/theories/examples/pool_counter__code.v
+++ b/theories/examples/pool_counter__code.v
@@ -12,14 +12,12 @@ From zoo Require Import
 
 Definition pool_counter_main : val :=
   fun: "num_domain" "n" =>
-    let: "pool" := pool_create "num_domain" in
     let: "cnt" := ref 0 in
     pool_run
-      "pool"
+      "num_domain"
       (fun: "ctx" =>
          for: <> := 0 to "n" begin
            pool_async "ctx" (fun: "_ctx" => FAA "cnt".[contents] 1 ;;
                                             ())
          end) ;;
-    pool_close "pool" ;;
     !"cnt".

--- a/theories/examples/pool_quicksort.v
+++ b/theories/examples/pool_quicksort.v
@@ -318,22 +318,22 @@ Section pool_G.
     iIntros "%Φ Harr HΦ".
 
     wp_rec.
-    wp_apply+ (pool_create_spec with "[//]") as (pool) "(_ & Hpool_model)". 1: lia.
 
-    wp_apply+ (pool_run_spec (λ _,
+    iApply wp_fupd.
+    wp_apply+ (pool_run_spec (λ pool res,
+      ⌜res = ()%V⌝ ∗
       pool_consumer pool (
         ∃ xs',
         ⌜xs ≡ₚ xs'⌝ ∗
         ⌜StronglySorted (≤)%Z xs'⌝ ∗
         array_model arr (DfracOwn 1) (#*@{Z} xs')
       )
-    )%I with "[$Hpool_model Harr]") as (?) "(Hpool_model & Hpool_consumer)".
-    { iIntros "%ctx %scope Hctx".
-      wp_apply+ (pool_quicksort_main_1_spec with "[$]") as "$".
+    )%I with "[Harr]") as (pool ?) "(#Hpool_finished & -> & Hpool_consumer)". 1: lia.
+    { iIntros "%pool %ctx %scope _ Hctx".
+      wp_apply+ (pool_quicksort_main_1_spec with "[$]").
+      iSteps.
     }
 
-    iApply wp_fupd.
-    wp_apply+ (pool_close_spec with "[$Hpool_model]") as "#Hpool_finished".
     iMod (pool_consumer_finished with "Hpool_consumer Hpool_finished") as "(%xs' & % & % & Harr)".
     iSteps.
   Qed.

--- a/theories/examples/pool_quicksort__code.v
+++ b/theories/examples/pool_quicksort__code.v
@@ -42,6 +42,4 @@ Definition pool_quicksort_main_1 : val :=
 
 Definition pool_quicksort_main : val :=
   fun: "num_domain" "arr" =>
-    let: "pool" := pool_create "num_domain" in
-    pool_run "pool" (fun: "ctx" => pool_quicksort_main_1 "ctx" "arr") ;;
-    pool_close "pool".
+    pool_run "num_domain" (fun: "ctx" => pool_quicksort_main_1 "ctx" "arr").

--- a/theories/examples/vertex_fibonacci.v
+++ b/theories/examples/vertex_fibonacci.v
@@ -126,12 +126,11 @@ Section vertex_fibonacci_G.
     iIntros "%Φ _ HΦ".
 
     wp_rec.
-    wp_apply+ (pool_create_spec with "[//]") as (pool) "(_ & Hpool_model)". 1: lia.
 
-    wp_apply+ (pool_run_spec (λ v,
+    wp_apply+ (pool_run_spec (λ pool v,
       ⌜v = #_⌝
-    )%I with "[$Hpool_model]") as (?) "(Hpool_model & ->)".
-    { iIntros "%ctx %scope Hctx".
+    )%I) as (pool ?) "(_ & ->)". 1: lia.
+    { iIntros "%pool %ctx %scope _ Hctx".
 
       wp_ref r as "Hr".
       wp_apply+ (vertex_create_spec
@@ -177,7 +176,6 @@ Section vertex_fibonacci_G.
       iSteps.
     }
 
-    wp_apply+ (pool_close_spec with "Hpool_model").
     iSteps.
   Qed.
 End vertex_fibonacci_G.

--- a/theories/examples/vertex_fibonacci__code.v
+++ b/theories/examples/vertex_fibonacci__code.v
@@ -37,24 +37,20 @@ Definition vertex_fibonacci_main_0 : val :=
 
 Definition vertex_fibonacci_main : val :=
   fun: "num_domain" "n" =>
-    let: "pool" := pool_create "num_domain" in
-    let: "res" :=
-      pool_run "pool"
-        (fun: "ctx" =>
-           let: "r" := ref 0 in
-           let: "vtx1" := vertex_create §None in
-           vertex_set_task
-             "vtx1"
-             (fun: "ctx" => vertex_fibonacci_main_0 "ctx" "vtx1" "r" "n") ;;
-           vertex_release "ctx" "vtx1" ;;
-           let: "flag" := mpsc_flag_create () in
-           let: "vtx2" :=
-             vertex_create' (fun: "_ctx" => mpsc_flag_set "flag")
-           in
-           vertex_precede "vtx1" "vtx2" ;;
-           vertex_release "ctx" "vtx2" ;;
-           pool_wait_until "ctx" (fun: <> => mpsc_flag_get "flag") ;;
-           !"r")
-    in
-    pool_close "pool" ;;
-    "res".
+    pool_run
+      "num_domain"
+      (fun: "ctx" =>
+         let: "r" := ref 0 in
+         let: "vtx1" := vertex_create §None in
+         vertex_set_task
+           "vtx1"
+           (fun: "ctx" => vertex_fibonacci_main_0 "ctx" "vtx1" "r" "n") ;;
+         vertex_release "ctx" "vtx1" ;;
+         let: "flag" := mpsc_flag_create () in
+         let: "vtx2" :=
+           vertex_create' (fun: "_ctx" => mpsc_flag_set "flag")
+         in
+         vertex_precede "vtx1" "vtx2" ;;
+         vertex_release "ctx" "vtx2" ;;
+         pool_wait_until "ctx" (fun: <> => mpsc_flag_get "flag") ;;
+         !"r").

--- a/theories/examples/vertex_simple.v
+++ b/theories/examples/vertex_simple.v
@@ -82,12 +82,11 @@ Section vertex_simple_G.
     wp_apply+ (vertex_precede_spec with "[$Hvtx_d_model]") as "(Hvtx_d_model & #Hvtx_b_predecessor)". 1: iFrame "#".
     wp_apply+ (vertex_precede_spec with "[$Hvtx_d_model]") as "(Hvtx_d_model & #Hvtx_c_predecessor)". 1: iFrame "#".
 
-    wp_apply+ (pool_create_spec with "[//]") as (pool) "(_ & Hpool_model)". 1: lia.
-
-    wp_apply+ (pool_run_spec (λ _,
+    wp_apply+ (pool_run_spec (λ pool res,
+      ⌜res = ()%V⌝ ∗
       P_d
-    )%I with "[- HΦ $Hpool_model]") as (?) "(Hpool_model & HP_d)".
-    { iIntros "%ctx %scope Hctx".
+    )%I with "[- HΦ]") as (pool ?) "(_ & -> & HP_d)". 1: lia.
+    { iIntros "%pool %ctx %scope _ Hctx".
 
       wp_apply+ (vertex_release_spec' with "[$Hctx $Hvtx_d_model Hvtx_b_output Hvtx_c_output Hd]") as "Hctx".
       { iFrame "#". iIntros "{%} %pool %ctx %scope Hctx #Hvtx_d_ready".
@@ -153,7 +152,6 @@ Section vertex_simple_G.
       iSteps.
     }
 
-    wp_apply+ (pool_close_spec with "[$Hpool_model]").
     iSteps.
   Qed.
 End vertex_simple_G.

--- a/theories/examples/vertex_simple__code.v
+++ b/theories/examples/vertex_simple__code.v
@@ -27,13 +27,11 @@ Definition vertex_simple_main : val :=
     vertex_precede "vtx_a" "vtx_c" ;;
     vertex_precede "vtx_b" "vtx_d" ;;
     vertex_precede "vtx_c" "vtx_d" ;;
-    let: "pool" := pool_create "num_domain" in
     pool_run
-      "pool"
+      "num_domain"
       (fun: "ctx" =>
          vertex_release "ctx" "vtx_d" ;;
          vertex_release "ctx" "vtx_c" ;;
          vertex_release "ctx" "vtx_b" ;;
          vertex_release "ctx" "vtx_a" ;;
-         pool_wait_until "ctx" (fun: <> => mpsc_flag_get "flag")) ;;
-    pool_close "pool".
+         pool_wait_until "ctx" (fun: <> => mpsc_flag_get "flag")).

--- a/theories/zoo_parabs/pool.v
+++ b/theories/zoo_parabs/pool.v
@@ -868,7 +868,7 @@ Module base.
       iFrameSteps.
     Qed.
 
-    Lemma pool_run_spec Ψ t γ task :
+    Lemma pool_run_on_spec Ψ t γ task :
       {{{
         pool_model t γ ∗
         ( ∀ ctx scope,
@@ -879,7 +879,7 @@ Module base.
           }}
         )
       }}}
-        pool_run #t task
+        pool_run_on #t task
       {{{
         v
       , RET v;
@@ -952,6 +952,39 @@ Module base.
       iMod (globals_model_close _ with "Hglobals_model Hlocals_ats") as "(%jobs & Hglobals_model & #Hjobs_auth & #Hjobs_finished)".
       iSplitL. { iFrameSteps. }
       iSteps.
+    Qed.
+
+    Lemma pool_run_spec (Ψ : location → pool_name → val → iProp Σ) sz task :
+      (0 ≤ sz)%Z →
+      {{{
+        ∀ t γ ctx scope,
+        pool_inv γ ₊sz -∗
+        meta_token t ⊤ -∗
+        pool_context γ ctx scope -∗
+        WP task ctx {{ v,
+          pool_context γ ctx scope ∗
+          Ψ t γ v
+        }}
+      }}}
+        pool_run #sz task
+      {{{
+        t γ v
+      , RET v;
+        pool_finished γ ∗
+        Ψ t γ v
+      }}}.
+    Proof.
+      iIntros "%Hsz %Φ Htask HΦ".
+
+      wp_rec.
+      wp_apply+ (pool_create_spec with "[//]") as (t γ) "(#Hinv & Hmodel & Hmeta)". 1: done.
+      wp_apply+ (pool_run_on_spec (Ψ t γ) with "[$Hmodel Hmeta Htask]") as (v) "(Hmodel & HΨ)".
+      { iIntros "%ctx %scope Hctx".
+        iApply ("Htask" with "Hinv Hmeta Hctx").
+      }
+      wp_apply+ (pool_close_spec with "Hmodel") as "#Hfinished".
+      wp_pures.
+      iApply ("HΦ" with "[$Hfinished $HΨ]").
     Qed.
 
     Lemma pool_size_spec γ sz ctx scope :
@@ -1132,6 +1165,7 @@ Section pool_G.
 
   Implicit Types 𝑡 : location.
   Implicit Types t : val.
+  Implicit Types γ : base.pool_name.
   Implicit Types P Q : iProp Σ.
   Implicit Types Ψ : val → iProp Σ.
 
@@ -1363,7 +1397,7 @@ Section pool_G.
     iSteps.
   Qed.
 
-  Lemma pool_run_spec Ψ t task :
+  Lemma pool_run_on_spec Ψ t task :
     {{{
       pool_model t ∗
       ( ∀ ctx scope,
@@ -1374,7 +1408,7 @@ Section pool_G.
         }}
       )
     }}}
-      pool_run t task
+      pool_run_on t task
     {{{
       v
     , RET v;
@@ -1384,7 +1418,7 @@ Section pool_G.
   Proof.
     iIntros "%Φ ((:model) & Htask) HΦ".
 
-    wp_apply (base.pool_run_spec Ψ with "[$Hmodel Htask]").
+    wp_apply (base.pool_run_on_spec Ψ with "[$Hmodel Htask]").
     { iIntros "%ctx %scope Hctx".
       wp_apply (wp_wand with "(Htask [$Hctx])") as (v) "((:context =1) & $)"; first iSteps.
       simplify.
@@ -1407,6 +1441,42 @@ Section pool_G.
     iIntros "%Φ (:model) HΦ".
 
     wp_apply (base.pool_close_spec with "Hmodel").
+    iSteps.
+  Qed.
+
+  Lemma pool_run_spec (Ψ : val → val → iProp Σ) sz task :
+    (0 ≤ sz)%Z →
+    {{{
+      ∀ t ctx scope,
+      pool_inv t ₊sz -∗
+      pool_context t ctx scope -∗
+      WP task ctx {{ v,
+        pool_context t ctx scope ∗
+        Ψ t v
+      }}
+    }}}
+      pool_run #sz task
+    {{{
+      t v
+    , RET v;
+      pool_finished t ∗
+      Ψ t v
+    }}}.
+  Proof.
+    iIntros "%Hsz %Φ Htask HΦ".
+
+    set (Ψ' 𝑡 γ v := (
+      meta 𝑡 nroot γ ∗
+      Ψ #𝑡 v
+    )%I).
+    wp_apply (base.pool_run_spec Ψ' with "[Htask]"). 1: done.
+    { iIntros "%𝑡 %γ %ctx %scope #Hinv Hmeta Hctx".
+      iMod (meta_set γ with "Hmeta") as "#Hmeta"; first done.
+      wp_apply (wp_wand with "(Htask [] [$Hctx])") as (v) "((:context =1) & HΨ)". 1-2: iSteps.
+      simplify.
+      iDestruct (meta_agree with "Hmeta Hmeta_1") as %->. iClear "Hmeta".
+      iFrameSteps.
+    }
     iSteps.
   Qed.
 

--- a/theories/zoo_parabs/pool__code.v
+++ b/theories/zoo_parabs/pool__code.v
@@ -60,7 +60,7 @@ Definition pool_create : val :=
     in
     { "sz", "hub", "domains", () }.
 
-Definition pool_run : val :=
+Definition pool_run_on : val :=
   fun: "t" "task" =>
     ws_hub_std_unblock "t".{hub} 0 ;;
     let: "res" := pool_execute (pool_context_main "t") "task" in
@@ -73,6 +73,13 @@ Definition pool_close : val :=
     ws_hub_std_unblock "t".{hub} 0 ;;
     pool_worker (pool_context_main "t") ;;
     array_iter domain_join "t".{domains}.
+
+Definition pool_run : val :=
+  fun: "num_domain" "task" =>
+    let: "t" := pool_create "num_domain" in
+    let: "res" := pool_run_on "t" "task" in
+    pool_close "t" ;;
+    "res".
 
 Definition pool_size : val :=
   fun: "ctx" =>

--- a/theories/zoo_parabs/pool__opaque.v
+++ b/theories/zoo_parabs/pool__opaque.v
@@ -2,8 +2,9 @@ From zoo_parabs Require Import
   pool__code.
 
 #[global] Opaque pool_create.
-#[global] Opaque pool_run.
+#[global] Opaque pool_run_on.
 #[global] Opaque pool_close.
+#[global] Opaque pool_run.
 #[global] Opaque pool_size.
 #[global] Opaque pool_async.
 #[global] Opaque pool_wait_until.


### PR DESCRIPTION
This PR introduces a new `Pool.run` function (the former one is renamed to `Pool.run_on`) that creates a new pool, runs the given task on it and closes the pool. This was suggested by @gasche in https://github.com/clef-men/zoo/issues/10.