### PR TITLE
New implementation of `Parabs.Waiters`

### DIFF
--- a/_RocqProject
+++ b/_RocqProject
@@ -462,6 +462,10 @@ theories/zoo_parabs/ws_deques_private__types.v
 theories/zoo_parabs/ws_deques_private__code.v
 theories/zoo_parabs/ws_deques_private__opaque.v
 theories/zoo_parabs/ws_deques_private.v
+theories/zoo_parabs/waiter__types.v
+theories/zoo_parabs/waiter__code.v
+theories/zoo_parabs/waiter__opaque.v
+theories/zoo_parabs/waiter.v
 theories/zoo_parabs/waiters__types.v
 theories/zoo_parabs/waiters__code.v
 theories/zoo_parabs/waiters__opaque.v

--- a/lib/zoo_parabs/waiter.ml
+++ b/lib/zoo_parabs/waiter.ml
@@ -1,0 +1,38 @@
+type t =
+  { mutex: Mutex.t
+  ; condition: Condition.t
+  ; mutable flag: bool
+  }
+
+let create () =
+  { mutex= Mutex.create ()
+  ; condition= Condition.create ()
+  ; flag= false
+  }
+
+let notify t =
+  if t.flag then (
+    false
+  ) else (
+    Mutex.lock t.mutex ;
+    if t.flag then (
+      Mutex.unlock t.mutex ;
+      false
+    ) else (
+      t.flag <- true ;
+      Mutex.unlock t.mutex ;
+      Condition.notify t.condition ;
+      true
+    )
+  )
+
+let prepare_wait t =
+  t.flag <- false
+
+let cancel_wait t =
+  t.flag <- true
+
+let commit_wait t =
+  if not @@ t.flag then
+    Mutex.protect t.mutex @@ fun () ->
+      Condition.wait_until t.condition t.mutex (fun () -> t.flag)

--- a/lib/zoo_parabs/waiter.mli
+++ b/lib/zoo_parabs/waiter.mli
@@ -1,0 +1,14 @@
+type t
+
+val create :
+  unit -> t
+
+val notify :
+  t -> bool
+
+val prepare_wait :
+  t -> unit
+val cancel_wait :
+  t -> unit
+val commit_wait :
+  t -> unit

--- a/lib/zoo_parabs/waiters.ml
+++ b/lib/zoo_parabs/waiters.ml
@@ -1,35 +1,38 @@
-type waiter =
-  Mpsc_waiter.t
-
 type t =
-  waiter Mpmc_queue_1.t
+  { waiters: Waiter.t array
+  ; queue: Waiter.t Mpmc_queue_1.t
+  }
 
-let create =
-  Mpmc_queue_1.create
+let create sz =
+  { waiters= Array.unsafe_init sz Waiter.create
+  ; queue= Mpmc_queue_1.create ()
+  }
 
-let rec notify' t =
-  match Mpmc_queue_1.pop t with
+let rec notify_one t =
+  match Mpmc_queue_1.pop t.queue with
   | None ->
-      false
+      ()
   | Some waiter ->
-      if Mpsc_waiter.notify waiter then
-        notify' t
-      else
-        true
-let notify t =
-  notify' t |> ignore
-let rec notify_many t n =
-  if 0 < n && notify' t then
-    notify_many t (n - 1)
+      if not @@ Waiter.notify waiter then
+        notify_one t
 
-let prepare_wait t =
-  let waiter = Mpsc_waiter.create () in
-  Mpmc_queue_1.push t waiter ;
-  waiter
+let rec notify_all t =
+  match Mpmc_queue_1.pop t.queue with
+  | None ->
+      ()
+  | Some waiter ->
+      Waiter.notify waiter |> ignore ;
+      notify_all t
 
-let cancel_wait t waiter =
-  if Mpsc_waiter.notify waiter then
-    notify t
+let prepare_wait t i =
+  let waiter = Array.unsafe_get t.waiters i in
+  Waiter.prepare_wait waiter ;
+  Mpmc_queue_1.push t.queue waiter
 
-let commit_wait _t waiter =
-  Mpsc_waiter.wait waiter
+let cancel_wait t i =
+  let waiter = Array.unsafe_get t.waiters i in
+  Waiter.cancel_wait waiter
+
+let commit_wait t i =
+  let waiter = Array.unsafe_get t.waiters i in
+  Waiter.commit_wait waiter

--- a/lib/zoo_parabs/waiters.mli
+++ b/lib/zoo_parabs/waiters.mli
@@ -1,18 +1,16 @@
 type t
 
-type waiter
-
 val create :
-  unit -> t
+  int -> t
 
-val notify :
+val notify_one :
   t -> unit
-val notify_many :
-  t -> int -> unit
+val notify_all :
+  t -> unit
 
 val prepare_wait :
-  t -> waiter
+  t -> int -> unit
 val cancel_wait :
-  t -> waiter -> unit
+  t -> int -> unit
 val commit_wait :
-  t -> waiter -> unit
+  t -> int -> unit

--- a/lib/zoo_parabs/ws_hub_fifo.ml
+++ b/lib/zoo_parabs/ws_hub_fifo.ml
@@ -8,7 +8,7 @@ type 'a t =
 let create sz =
   { size= sz
   ; queue= Mpmc_queue_1.create ()
-  ; waiters= Waiters.create ()
+  ; waiters= Waiters.create sz
   ; num_active= sz + 1
   }
 
@@ -29,9 +29,9 @@ let closed t =
   t.num_active == 0
 
 let notify t =
-  Waiters.notify t.waiters
+  Waiters.notify_one t.waiters
 let notify_all t =
-  Waiters.notify_many t.waiters (size t)
+  Waiters.notify_all t.waiters
 
 let push t _i v =
   Mpmc_queue_1.push t.queue v ;
@@ -56,28 +56,27 @@ let rec steal_until t pred =
 let steal_until t _i ~max_round_noyield:_ pred =
   steal_until t pred
 
-let rec steal t =
-  let waiters = t.waiters in
-  let waiter = Waiters.prepare_wait waiters in
+let rec steal t i =
+  Waiters.prepare_wait t.waiters i ;
   if closed t then (
     notify_all t ;
     None
   ) else (
     if Mpmc_queue_1.is_empty t.queue then (
-      Waiters.commit_wait waiters waiter
+      Waiters.commit_wait t.waiters i
     ) else (
-      Waiters.cancel_wait waiters waiter
+      Waiters.cancel_wait t.waiters i
     ) ;
     match pop' t with
     | Some _ as res ->
         end_inactive t ;
         res
     | None ->
-        steal t
+        steal t i
   )
-let steal t _i ~max_round_noyield:_ ~max_round_yield:_ =
+let steal t i ~max_round_noyield:_ ~max_round_yield:_ =
   begin_inactive t ;
-  steal t
+  steal t i
 
 let close =
   begin_inactive

--- a/lib/zoo_parabs/ws_hub_std.ml
+++ b/lib/zoo_parabs/ws_hub_std.ml
@@ -12,7 +12,7 @@ type 'a t =
 let create sz =
   { queues= Ws_deques_public.create sz
   ; rounds= Array.unsafe_init sz (fun _ -> Random_round.create @@ Int.positive_part @@ sz - 1)
-  ; waiters= Waiters.create ()
+  ; waiters= Waiters.create sz
   ; num_active= sz + 1
   }
 
@@ -40,9 +40,9 @@ let closed t =
   t.num_active == 0
 
 let notify t =
-  Waiters.notify t.waiters
+  Waiters.notify_one t.waiters
 let notify_all t =
-  Waiters.notify_many t.waiters (size t)
+  Waiters.notify_all t.waiters
 
 let push t i v =
   Ws_deques_public.push t.queues i v ;
@@ -114,11 +114,10 @@ let rec steal t i ~max_round_noyield ~max_round_yield =
       notify_all t ;
       None
   | Nothing ->
-      let waiters = t.waiters in
-      let waiter = Waiters.prepare_wait waiters in
+      Waiters.prepare_wait t.waiters i ;
       match try_steal_once t i with
       | Some _ as res ->
-          Waiters.cancel_wait waiters waiter ;
+          Waiters.cancel_wait t.waiters i ;
           unblock t i ;
           res
       | None ->
@@ -126,7 +125,7 @@ let rec steal t i ~max_round_noyield ~max_round_yield =
             notify_all t ;
             None
           ) else (
-            Waiters.commit_wait waiters waiter ;
+            Waiters.commit_wait t.waiters i ;
             steal t i ~max_round_noyield ~max_round_yield
           )
 let steal t i ~max_round_noyield ~max_round_yield =

--- a/theories/zoo_parabs/waiter.v
+++ b/theories/zoo_parabs/waiter.v
@@ -1,0 +1,211 @@
+From zoo Require Import
+  prelude.
+From zoo.language Require Import
+  notations.
+From zoo.diaframe Require Import
+  diaframe.
+From zoo_std Require Import
+  condition
+  mutex.
+From zoo_saturn Require Import
+  mpmc_queue_1.
+From zoo_parabs Require Export
+  base
+  waiter__code.
+From zoo_parabs Require Import
+  base
+  waiter__types.
+From zoo Require Import
+  options.
+
+Implicit Types b : bool.
+Implicit Types 𝑡 : location.
+Implicit Types v t mtx cond : val.
+
+Class WaiterG Σ `{zoo_G : !ZooG Σ} :=
+  { #[local] waiter_G_mutex_G :: MutexG Σ
+  }.
+
+Definition waiter_Σ := #[
+  mutex_Σ
+].
+#[global] Instance subG_ws_hub_Σ Σ `{zoo_G : !ZooG Σ} :
+  subG waiter_Σ Σ →
+  WaiterG Σ.
+Proof.
+  solve_inG.
+Qed.
+
+Section waiter_G.
+  Context `{waiter_G : WaiterG Σ}.
+
+  #[local] Definition waiter_inv_inner 𝑡 : iProp Σ :=
+    ∃ b,
+    𝑡.[flag] ↦ #b.
+  #[local] Instance : CustomIpat "inv_inner" :=
+    " ( %b
+      & H𝑡_flag
+      )
+    ".
+  Definition waiter_inv t : iProp Σ :=
+    ∃ 𝑡 mtx cond,
+    ⌜t = #𝑡⌝ ∗
+    𝑡.[mutex] ↦□ mtx ∗
+    mutex_inv mtx True ∗
+    𝑡.[condition] ↦□ cond ∗
+    condition_inv cond ∗
+    inv nroot (waiter_inv_inner 𝑡).
+  #[local] Instance : CustomIpat "inv" :=
+    " ( %𝑡
+      & %mtx
+      & %cond
+      & ->
+      & #H𝑡_mutex
+      & #Hmutex_inv
+      & #H𝑡_condition
+      & #Hcondition_inv
+      & #Hinv
+      )
+    ".
+
+  #[global] Instance waiter_inv_persistent t :
+    Persistent (waiter_inv t).
+  Proof.
+    apply _.
+  Qed.
+
+  Lemma waiter_create𑁒spec :
+    {{{
+      True
+    }}}
+      waiter_create ()
+    {{{
+      t
+    , RET t;
+      waiter_inv t
+    }}}.
+  Proof.
+    iIntros "%Φ _ HΦ".
+
+    wp_rec.
+    wp_apply+ (condition_create𑁒spec with "[//]") as "%cond #Hcondition_inv".
+    wp_apply+ (mutex_create𑁒spec True with "[//]") as "%mtx #Hmutex_inv".
+
+    iSteps.
+  Qed.
+
+  Lemma waiter_notify𑁒spec t :
+    {{{
+      waiter_inv t
+    }}}
+      waiter_notify t
+    {{{
+      b
+    , RET #b;
+      True
+    }}}.
+  Proof.
+    iIntros "%Φ (:inv) HΦ".
+
+    wp_rec.
+
+    wp_bind (_.{flag})%E.
+    iInv "Hinv" as "(:inv_inner)".
+    wp_load.
+    destruct b. 1: iSteps.
+    iSplitR "HΦ". { iFrameSteps. }
+    iModIntro.
+
+    wp_load.
+    wp_apply (mutex_lock𑁒spec with "Hmutex_inv") as "(Hmutex_locked & _)".
+    wp_pures.
+
+    wp_bind (_.{flag})%E.
+    iInv "Hinv" as "(:inv_inner)".
+    wp_load.
+    iSplitR "Hmutex_locked HΦ". { iFrameSteps. }
+    iModIntro.
+
+    destruct b; wp_pures.
+
+    - wp_load.
+      wp_apply (mutex_unlock𑁒spec with "[$Hmutex_inv $Hmutex_locked //]") as "_".
+      iSteps.
+
+    - wp_bind (_ <-{flag} _)%E.
+      iInv "Hinv" as "(:inv_inner)".
+      wp_store.
+      iSplitR "Hmutex_locked HΦ". { iFrameSteps. }
+      iModIntro.
+
+      wp_load.
+      wp_apply (mutex_unlock𑁒spec with "[$Hmutex_inv $Hmutex_locked //]") as "_".
+      wp_load.
+      wp_apply (condition_notify𑁒spec with "Hcondition_inv").
+      iSteps.
+  Qed.
+
+  Lemma waiter_prepare_wait𑁒spec t :
+    {{{
+      waiter_inv t
+    }}}
+      waiter_prepare_wait t
+    {{{
+      RET ();
+      True
+    }}}.
+  Proof.
+    iSteps.
+  Qed.
+
+  Lemma waiter_cancel_wait𑁒spec t :
+    {{{
+      waiter_inv t
+    }}}
+      waiter_cancel_wait t
+    {{{
+      RET ();
+      True
+    }}}.
+  Proof.
+    iSteps.
+  Qed.
+
+  Lemma waiter_commit_wait𑁒spec t :
+    {{{
+      waiter_inv t
+    }}}
+      waiter_commit_wait t
+    {{{
+      RET ();
+      True
+    }}}.
+  Proof.
+    iIntros "%Φ (:inv) HΦ".
+
+    wp_rec.
+
+    wp_bind (_.{flag})%E.
+    iInv "Hinv" as "(:inv_inner)".
+    wp_load.
+    destruct b. 1: iSteps.
+    iSplitR "HΦ". { iFrameSteps. }
+    iModIntro.
+
+    wp_load.
+    wp_apply+ (mutex_protect𑁒spec (λ res,
+      ⌜res = ()%V⌝
+    )%I with "[$Hmutex_inv]").
+    { iIntros "Hmutex_locked _".
+      do 2 wp_load.
+      wp_apply (condition_wait_until𑁒spec (λ _, True)%I with "[$Hcondition_inv $Hmutex_inv $Hmutex_locked]").
+      all: iSteps.
+    }
+    iSteps.
+  Qed.
+End waiter_G.
+
+From zoo_parabs Require
+  waiter__opaque.
+
+#[global] Opaque waiter_inv.

--- a/theories/zoo_parabs/waiter__code.v
+++ b/theories/zoo_parabs/waiter__code.v
@@ -1,0 +1,52 @@
+From zoo Require Import
+  prelude.
+From zoo.language Require Import
+  typeclasses
+  notations.
+From zoo_std Require Import
+  condition
+  mutex.
+From zoo_parabs Require Import
+  waiter__types.
+From zoo Require Import
+  options.
+
+Definition waiter_create : val :=
+  fun: <> =>
+    { mutex_create (), condition_create (), false }.
+
+Definition waiter_notify : val :=
+  fun: "t" =>
+    if: "t".{flag} then (
+      false
+    ) else (
+      mutex_lock "t".{mutex} ;;
+      if: "t".{flag} then (
+        mutex_unlock "t".{mutex} ;;
+        false
+      ) else (
+        "t" <-{flag} true ;;
+        mutex_unlock "t".{mutex} ;;
+        condition_notify "t".{condition} ;;
+        true
+      )
+    ).
+
+Definition waiter_prepare_wait : val :=
+  fun: "t" =>
+    "t" <-{flag} false.
+
+Definition waiter_cancel_wait : val :=
+  fun: "t" =>
+    "t" <-{flag} true.
+
+Definition waiter_commit_wait : val :=
+  fun: "t" =>
+    if: ~ "t".{flag} then (
+      mutex_protect "t".{mutex}
+        (fun: <> =>
+           condition_wait_until
+             "t".{condition}
+             "t".{mutex}
+             (fun: <> => "t".{flag}))
+    ).

--- a/theories/zoo_parabs/waiter__opaque.v
+++ b/theories/zoo_parabs/waiter__opaque.v
@@ -1,0 +1,8 @@
+From zoo_parabs Require Import
+  waiter__code.
+
+#[global] Opaque waiter_create.
+#[global] Opaque waiter_notify.
+#[global] Opaque waiter_prepare_wait.
+#[global] Opaque waiter_cancel_wait.
+#[global] Opaque waiter_commit_wait.

--- a/theories/zoo_parabs/waiter__types.v
+++ b/theories/zoo_parabs/waiter__types.v
@@ -1,0 +1,23 @@
+From zoo Require Import
+  prelude.
+From zoo.language Require Import
+  typeclasses
+  notations.
+From zoo_std Require Import
+  condition
+  mutex.
+From zoo Require Import
+  options.
+
+Notation "'mutex'" := (
+  in_type "zoo_parabs.waiter.t" 0
+)(in custom zoo_field
+).
+Notation "'condition'" := (
+  in_type "zoo_parabs.waiter.t" 1
+)(in custom zoo_field
+).
+Notation "'flag'" := (
+  in_type "zoo_parabs.waiter.t" 2
+)(in custom zoo_field
+).

--- a/theories/zoo_parabs/waiters.v
+++ b/theories/zoo_parabs/waiters.v
@@ -5,27 +5,29 @@ From zoo.language Require Import
 From zoo.diaframe Require Import
   diaframe.
 From zoo_std Require Import
-  option
-  mpsc_waiter.
+  array.
 From zoo_saturn Require Import
   mpmc_queue_1.
 From zoo_parabs Require Export
   base
   waiters__code.
+From zoo_parabs Require Import
+  waiter
+  waiters__types.
 From zoo Require Import
   options.
 
-Implicit Types b : bool.
-Implicit Types v t : val.
+Implicit Types v t waiters queue : val.
+Implicit Types 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 𝑞𝑢𝑒𝑢𝑒 : list val.
 
 Class WaitersG Σ `{zoo_G : !ZooG Σ} :=
   { #[local] waiters_G_queue_G :: MpmcQueue1G Σ
-  ; #[local] waiters_G_waiter_G :: MpscWaiterG Σ
+  ; #[local] waiters_G_waiter_G :: WaiterG Σ
   }.
 
 Definition waiters_Σ := #[
   mpmc_queue_1_Σ ;
-  mpsc_waiter_Σ
+  waiter_Σ
 ].
 #[global] Instance subG_ws_hub_Σ Σ `{zoo_G : !ZooG Σ} :
   subG waiters_Σ Σ →
@@ -37,175 +39,196 @@ Qed.
 Section waiters_G.
   Context `{waiters_G : WaitersG Σ}.
 
-  #[local] Definition waiters_inv_inner t : iProp Σ :=
-    ∃ waiters,
-    mpmc_queue_1_model t waiters ∗
-    [∗ list] waiter ∈ waiters,
-      mpsc_waiter_inv waiter True.
-  Definition waiters_inv t : iProp Σ :=
-    mpmc_queue_1_inv t (nroot.@"queue") ∗
-    inv (nroot.@"inv") (waiters_inv_inner t).
+  #[local] Definition waiters_inv_inner queue : iProp Σ :=
+    ∃ 𝑞𝑢𝑒𝑢𝑒,
+    mpmc_queue_1_model queue 𝑞𝑢𝑒𝑢𝑒 ∗
+    [∗ list] 𝑤𝑎𝑖𝑡𝑒𝑟 ∈ 𝑞𝑢𝑒𝑢𝑒,
+      waiter_inv 𝑤𝑎𝑖𝑡𝑒𝑟.
+  #[local] Instance : CustomIpat "inv_inner" :=
+    " ( %𝑞𝑢𝑒𝑢𝑒
+      & >Hqueue_model
+      & H𝑞𝑢𝑒𝑢𝑒
+      )
+    ".
+  Definition waiters_inv t sz : iProp Σ :=
+    ∃ waiters 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 queue,
+    ⌜t = (waiters, queue)%V⌝ ∗
+    array_model waiters Discard 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 ∗
+    ⌜length 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 = sz⌝ ∗
+    ([∗ list] 𝑤𝑎𝑖𝑡𝑒𝑟 ∈ 𝑤𝑎𝑖𝑡𝑒𝑟𝑠, waiter_inv 𝑤𝑎𝑖𝑡𝑒𝑟) ∗
+    mpmc_queue_1_inv queue (nroot.@"queue") ∗
+    inv (nroot.@"inv") (waiters_inv_inner queue).
+  #[local] Instance : CustomIpat "inv" :=
+    " ( %waiters
+      & %𝑤𝑎𝑖𝑡𝑒𝑟𝑠
+      & %queue
+      & ->
+      & #Hwaiters
+      & %H𝑤𝑎𝑖𝑡𝑒𝑟s
+      & #H𝑤𝑎𝑖𝑡𝑒𝑟𝑠
+      & #Hqueue_inv
+      & #Hinv
+      )
+    ".
 
-  Definition waiters_waiter t waiter : iProp Σ :=
-    mpsc_waiter_inv waiter True ∗
-    mpsc_waiter_consumer waiter.
-
-  #[global] Instance waiters_inv_persistent t :
-    Persistent (waiters_inv t).
+  #[global] Instance waiters_inv_persistent t sz :
+    Persistent (waiters_inv t sz).
   Proof.
     apply _.
   Qed.
 
-  Lemma waiters_waiter_exclusive t1 t2 waiter :
-    waiters_waiter t1 waiter -∗
-    waiters_waiter t2 waiter -∗
-    False.
-  Proof.
-    iIntros "(_ & Hwaiter_consumer1) (_ & Hwaiter_consumer2)".
-    iApply (mpsc_waiter_consumer_exclusive with "Hwaiter_consumer1 Hwaiter_consumer2").
-  Qed.
-
-  Lemma waiters_create𑁒spec :
+  Lemma waiters_create𑁒spec sz :
+    (0 ≤ sz)%Z →
     {{{
       True
     }}}
-      waiters_create ()
+      waiters_create #sz
     {{{
       t
     , RET t;
-      waiters_inv t
+      waiters_inv t ₊sz
     }}}.
   Proof.
-    iIntros "%Φ _ HΦ".
+    iIntros "%Hsz %Φ _ HΦ".
 
-    iApply wp_fupd.
+    wp_rec.
     wp_apply (mpmc_queue_1_create𑁒spec with "[//]") as (t) "(#Hqueue_inv & Hmodel)".
+
+    wp_apply (array_unsafe_init𑁒spec_disentangled (λ _ 𝑤𝑎𝑖𝑡𝑒𝑟,
+      waiter_inv 𝑤𝑎𝑖𝑡𝑒𝑟
+    )%I) as (waiters 𝑤𝑎𝑖𝑡𝑒𝑟𝑠) "(%H𝑤𝑎𝑖𝑡𝑒𝑟𝑠 & Hwaiters & H𝑤𝑎𝑖𝑡𝑒𝑟𝑠)". 1: done.
+    { iIntros "!> %i %Hi".
+      wp_apply (waiter_create𑁒spec with "[//]").
+      iSteps.
+    }
+    iMod (array_model_persist with "Hwaiters") as "#Hwaiters".
+
     iSteps.
   Qed.
 
-  #[local] Lemma waiters_notify'𑁒spec t :
+  Lemma waiters_notify_one𑁒spec t sz :
     {{{
-      waiters_inv t
+      waiters_inv t sz
     }}}
-      waiters_notify' t
+      waiters_notify_one t
     {{{
-      b
-    , RET #b;
+      RET ();
       True
     }}}.
   Proof.
-    iIntros "%Φ (#Hqueue_inv & #Hinv) HΦ".
+    iIntros "%Φ (:inv) HΦ".
 
     iLöb as "HLöb".
 
     wp_rec.
 
-    awp_apply (mpmc_queue_1_pop𑁒spec with "Hqueue_inv") without "HΦ".
-    iInv "Hinv" as "(%waiters & >Hmodel & Hwaiters)".
-    iAaccIntro with "Hmodel"; first iSteps. iIntros "Hmodel !>".
-    destruct waiters as [| waiter waiters]; first iSteps.
-    iDestruct "Hwaiters" as "(Hwaiter & Hwaiters)".
-    iSplitR "Hwaiter"; first iSteps.
+    awp_apply+ (mpmc_queue_1_pop𑁒spec with "Hqueue_inv") without "HΦ".
+    iInv "Hinv" as "(:inv_inner)".
+    iAaccIntro with "Hqueue_model". 1: iSteps. iIntros "Hqueue_model !>".
+    destruct 𝑞𝑢𝑒𝑢𝑒 as [| 𝑤𝑎𝑖𝑡𝑒𝑟 𝑞𝑢𝑒𝑢𝑒]. 1: iSteps.
+    iDestruct "H𝑞𝑢𝑒𝑢𝑒" as "(H𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑞𝑢𝑒𝑢𝑒)".
+    iSplitR "H𝑤𝑎𝑖𝑡𝑒𝑟". { iFrame. }
     iIntros "_ HΦ".
 
-    wp_apply+ (mpsc_waiter_notify𑁒spec with "[$Hwaiter //]") as ([]) "_"; last iSteps.
+    wp_apply+ (waiter_notify𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟") as ([]) "_". 1: iSteps.
     wp_apply+ ("HLöb" with "HΦ").
   Qed.
 
-  Lemma waiters_notify𑁒spec t :
+  Lemma waiters_notify_all𑁒spec t sz :
     {{{
-      waiters_inv t
+      waiters_inv t sz
     }}}
-      waiters_notify t
+      waiters_notify_all t
     {{{
       RET ();
       True
     }}}.
   Proof.
-    iIntros "%Φ #Hinv HΦ".
+    iIntros "%Φ (:inv) HΦ".
+
+    iLöb as "HLöb".
 
     wp_rec.
-    wp_apply (waiters_notify'𑁒spec with "Hinv").
+
+    awp_apply+ (mpmc_queue_1_pop𑁒spec with "Hqueue_inv") without "HΦ".
+    iInv "Hinv" as "(:inv_inner)".
+    iAaccIntro with "Hqueue_model". 1: iSteps. iIntros "Hqueue_model !>".
+    destruct 𝑞𝑢𝑒𝑢𝑒 as [| 𝑤𝑎𝑖𝑡𝑒𝑟 𝑞𝑢𝑒𝑢𝑒]. 1: iSteps.
+    iDestruct "H𝑞𝑢𝑒𝑢𝑒" as "(H𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑞𝑢𝑒𝑢𝑒)".
+    iSplitR "H𝑤𝑎𝑖𝑡𝑒𝑟". { iFrame. }
+    iIntros "_ HΦ".
+
+    wp_apply+ (waiter_notify𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟") as (res) "_".
+    wp_apply+ ("HLöb" with "HΦ").
+  Qed.
+
+  Lemma waiters_prepare_wait𑁒spec t (sz : nat) i :
+    (0 ≤ i < sz)%Z →
+    {{{
+      waiters_inv t sz
+    }}}
+      waiters_prepare_wait t #i
+    {{{
+      RET ();
+      True
+    }}}.
+  Proof.
+    iIntros "%Hi %Φ (:inv) HΦ".
+
+    destruct (lookup_lt_is_Some_2 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 ₊i) as (𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑤𝑎𝑖𝑡𝑒𝑟𝑠_lookup). 1: lia.
+    iDestruct (big_sepL_lookup with "H𝑤𝑎𝑖𝑡𝑒𝑟𝑠") as "H𝑤𝑎𝑖𝑡𝑒𝑟". 1: done.
+
+    wp_rec.
+    wp_apply+ (array_unsafe_get𑁒spec with "Hwaiters") as "_". 1-3: done || lia.
+    wp_apply+ (waiter_prepare_wait𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟") as "_".
+
+    awp_apply+ (mpmc_queue_1_push𑁒spec with "Hqueue_inv") without "HΦ".
+    iInv "Hinv" as "(:inv_inner)".
+    iAaccIntro with "Hqueue_model". 1: iSteps. iIntros "Hqueue_model !>".
+    iSplitL. { iFrameSteps. }
     iSteps.
   Qed.
 
-  Lemma waiters_notify_many𑁒spec t n :
-    (0 ≤ n)%Z →
+  Lemma waiters_cancel_wait𑁒spec t (sz : nat) i :
+    (0 ≤ i < sz)%Z →
     {{{
-      waiters_inv t
+      waiters_inv t sz
     }}}
-      waiters_notify_many t #n
+      waiters_cancel_wait t #i
     {{{
       RET ();
       True
     }}}.
   Proof.
-    iIntros "%Hn %Φ #Hinv HΦ".
+    iIntros "%Hi %Φ (:inv) HΦ".
 
-    iLöb as "HLöb" forall (n Hn).
-
-    wp_rec. wp_pures.
-    case_bool_decide; last iSteps.
-    wp_apply+ (waiters_notify'𑁒spec with "Hinv") as ([]) "_"; last iSteps.
-    wp_apply+ ("HLöb" with "[] HΦ"); first iSteps.
-  Qed.
-
-  Lemma waiters_prepare_wait𑁒spec t :
-    {{{
-      waiters_inv t
-    }}}
-      waiters_prepare_wait t
-    {{{
-      waiter
-    , RET waiter;
-      waiters_waiter t waiter
-    }}}.
-  Proof.
-    iIntros "%Φ (#Hqueue_inv & #Hinv) HΦ".
+    destruct (lookup_lt_is_Some_2 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 ₊i) as (𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑤𝑎𝑖𝑡𝑒𝑟𝑠_lookup). 1: lia.
+    iDestruct (big_sepL_lookup with "H𝑤𝑎𝑖𝑡𝑒𝑟𝑠") as "H𝑤𝑎𝑖𝑡𝑒𝑟". 1: done.
 
     wp_rec.
-    wp_apply (mpsc_waiter_create𑁒spec with "[//]") as (waiter) "(#Hwaiter_inv & Hwaiter_consumer)".
-
-    awp_apply+ (mpmc_queue_1_push𑁒spec with "Hqueue_inv") without "Hwaiter_consumer HΦ".
-    iInv "Hinv" as "(%waiters & >Hmodel & Hwaiters)".
-    iAaccIntro with "Hmodel"; first iSteps. iIntros "Hmodel !>".
-    iSplitL. { iSteps. iApply big_sepL_snoc. iSteps. }
-    iSteps.
+    wp_apply+ (array_unsafe_get𑁒spec with "Hwaiters") as "_". 1-3: done || lia.
+    wp_apply+ (waiter_cancel_wait𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟 HΦ").
   Qed.
 
-  Lemma waiters_cancel_wait𑁒spec t waiter :
+  Lemma waiters_commit_wait𑁒spec t (sz : nat) i :
+    (0 ≤ i < sz)%Z →
     {{{
-      waiters_inv t ∗
-      waiters_waiter t waiter
+      waiters_inv t sz
     }}}
-      waiters_cancel_wait t waiter
+      waiters_commit_wait t #i
     {{{
       RET ();
       True
     }}}.
   Proof.
-    iIntros "%Φ (#Hinv & (#Hwaiter_inv & Hwaiter_consumer)) HΦ".
+    iIntros "%Hi %Φ (:inv) HΦ".
+
+    destruct (lookup_lt_is_Some_2 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 ₊i) as (𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑤𝑎𝑖𝑡𝑒𝑟𝑠_lookup). 1: lia.
+    iDestruct (big_sepL_lookup with "H𝑤𝑎𝑖𝑡𝑒𝑟𝑠") as "H𝑤𝑎𝑖𝑡𝑒𝑟". 1: done.
 
     wp_rec.
-    wp_apply+ (mpsc_waiter_notify𑁒spec with "[$Hwaiter_inv //]") as ([]) "_"; last iSteps.
-    wp_apply+ (waiters_notify𑁒spec with "Hinv HΦ").
-  Qed.
-
-  Lemma waiters_commit_wait𑁒spec t waiter :
-    {{{
-      waiters_inv t ∗
-      waiters_waiter t waiter
-    }}}
-      waiters_commit_wait t waiter
-    {{{
-      RET ();
-      True
-    }}}.
-  Proof.
-    iIntros "%Φ (#Hinv & (#Hwaiter_inv & Hwaiter_consumer)) HΦ".
-
-    wp_rec.
-    wp_apply+ (mpsc_waiter_wait𑁒spec with "[$Hwaiter_inv $Hwaiter_consumer] HΦ").
+    wp_apply+ (array_unsafe_get𑁒spec with "Hwaiters") as "_". 1-3: done || lia.
+    wp_apply+ (waiter_commit_wait𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟 HΦ").
   Qed.
 End waiters_G.
 
@@ -213,4 +236,3 @@ From zoo_parabs Require
   waiters__opaque.
 
 #[global] Opaque waiters_inv.
-#[global] Opaque waiters_waiter.

--- a/theories/zoo_parabs/waiters__code.v
+++ b/theories/zoo_parabs/waiters__code.v
@@ -3,54 +3,54 @@ From zoo Require Import
 From zoo.language Require Import
   typeclasses
   notations.
+From zoo_parabs Require Import
+  waiter.
 From zoo_saturn Require Import
   mpmc_queue_1.
 From zoo_std Require Import
-  mpsc_waiter.
+  array.
 From zoo_parabs Require Import
   waiters__types.
 From zoo Require Import
   options.
 
 Definition waiters_create : val :=
-  mpmc_queue_1_create.
+  fun: "sz" =>
+    (array_unsafe_init "sz" waiter_create, mpmc_queue_1_create ()).
 
-Definition waiters_notify' : val :=
-  rec: "notify'" "t" =>
-    match: mpmc_queue_1_pop "t" with
+Definition waiters_notify_one : val :=
+  rec: "notify_one" "t" =>
+    match: mpmc_queue_1_pop "t".<queue> with
     | None =>
-        false
+        ()
     | Some "waiter" =>
-        if: mpsc_waiter_notify "waiter" then (
-          "notify'" "t"
-        ) else (
-          true
+        if: ~ waiter_notify "waiter" then (
+          "notify_one" "t"
         )
     end.
 
-Definition waiters_notify : val :=
-  fun: "t" =>
-    waiters_notify' "t" ;;
-    ().
-
-Definition waiters_notify_many : val :=
-  rec: "notify_many" "t" "n" =>
-    if: 0 < "n" and waiters_notify' "t" then (
-      "notify_many" "t" ("n" - 1)
-    ).
+Definition waiters_notify_all : val :=
+  rec: "notify_all" "t" =>
+    match: mpmc_queue_1_pop "t".<queue> with
+    | None =>
+        ()
+    | Some "waiter" =>
+        waiter_notify "waiter" ;;
+        "notify_all" "t"
+    end.
 
 Definition waiters_prepare_wait : val :=
-  fun: "t" =>
-    let: "waiter" := mpsc_waiter_create () in
-    mpmc_queue_1_push "t" "waiter" ;;
-    "waiter".
+  fun: "t" "i" =>
+    let: "waiter" := array_unsafe_get "t".<waiters> "i" in
+    waiter_prepare_wait "waiter" ;;
+    mpmc_queue_1_push "t".<queue> "waiter".
 
 Definition waiters_cancel_wait : val :=
-  fun: "t" "waiter" =>
-    if: mpsc_waiter_notify "waiter" then (
-      waiters_notify "t"
-    ).
+  fun: "t" "i" =>
+    let: "waiter" := array_unsafe_get "t".<waiters> "i" in
+    waiter_cancel_wait "waiter".
 
 Definition waiters_commit_wait : val :=
-  fun: "_t" "waiter" =>
-    mpsc_waiter_wait "waiter".
+  fun: "t" "i" =>
+    let: "waiter" := array_unsafe_get "t".<waiters> "i" in
+    waiter_commit_wait "waiter".

--- a/theories/zoo_parabs/waiters__opaque.v
+++ b/theories/zoo_parabs/waiters__opaque.v
@@ -2,8 +2,8 @@ From zoo_parabs Require Import
   waiters__code.
 
 #[global] Opaque waiters_create.
-#[global] Opaque waiters_notify.
-#[global] Opaque waiters_notify_many.
+#[global] Opaque waiters_notify_one.
+#[global] Opaque waiters_notify_all.
 #[global] Opaque waiters_prepare_wait.
 #[global] Opaque waiters_cancel_wait.
 #[global] Opaque waiters_commit_wait.

--- a/theories/zoo_parabs/waiters__types.v
+++ b/theories/zoo_parabs/waiters__types.v
@@ -3,10 +3,20 @@ From zoo Require Import
 From zoo.language Require Import
   typeclasses
   notations.
+From zoo_parabs Require Import
+  waiter.
 From zoo_saturn Require Import
   mpmc_queue_1.
 From zoo_std Require Import
-  mpsc_waiter.
+  array.
 From zoo Require Import
   options.
 
+Notation "'waiters'" := (
+  in_type "zoo_parabs.waiters.t" 0
+)(in custom zoo_proj
+).
+Notation "'queue'" := (
+  in_type "zoo_parabs.waiters.t" 1
+)(in custom zoo_proj
+).

--- a/theories/zoo_parabs/ws_hub_fifo.v
+++ b/theories/zoo_parabs/ws_hub_fifo.v
@@ -27,7 +27,7 @@ From zoo Require Import
 
 Implicit Types b closed : bool.
 Implicit Types num_active : Z.
-Implicit Types l : location.
+Implicit Types 𝑡 : location.
 Implicit Types v t until pred : val.
 Implicit Types ws : list val.
 Implicit Types vs : gmultiset val.
@@ -106,15 +106,17 @@ Section ws_hub_fifo_G.
     solve_countable.
   Qed.
 
-  #[local] Definition owner' γ_owners i : iProp Σ :=
+  #[local] Definition owner' γ_owners sz i : iProp Σ :=
     ∃ γ_owner,
     ⌜γ_owners !! i = Some γ_owner⌝ ∗
+    ⌜length γ_owners = sz⌝ ∗
     excl γ_owner ().
   #[local] Definition owner γ i :=
-    owner' γ.(metadata_owners) i.
+    owner' γ.(metadata_owners) γ.(metadata_size) i.
   #[local] Instance : CustomIpat "owner_" :=
     " ( %γ_owner{}
       & %Hlookup{}
+      & %Hlength{_{}}
       & Howner{}
       )
     ".
@@ -141,34 +143,34 @@ Section ws_hub_fifo_G.
   #[local] Definition emptiness_at γ :=
     emptiness_at' γ.(metadata_emptiness).
 
-  #[local] Definition inv_inner l : iProp Σ :=
+  #[local] Definition inv_inner 𝑡 : iProp Σ :=
     ∃ num_active,
-    l.[num_active] ↦ #num_active.
+    𝑡.[num_active] ↦ #num_active.
   #[local] Instance : CustomIpat "inv_inner" :=
     " ( %num_active
-      & Hl_num_active
+      & H𝑡_num_active
       )
     ".
   Definition ws_hub_fifo_inv t ι (sz : nat) : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
     ⌜sz = γ.(metadata_size)⌝ ∗
-    meta l nroot γ ∗
-    l.[size] ↦□ #γ.(metadata_size) ∗
-    l.[queue] ↦□ γ.(metadata_queue) ∗
-    l.[waiters] ↦□ γ.(metadata_waiters) ∗
+    meta 𝑡 nroot γ ∗
+    𝑡.[size] ↦□ #γ.(metadata_size) ∗
+    𝑡.[queue] ↦□ γ.(metadata_queue) ∗
+    𝑡.[waiters] ↦□ γ.(metadata_waiters) ∗
     mpmc_queue_1_inv γ.(metadata_queue) ι ∗
-    waiters_inv γ.(metadata_waiters) ∗
-    inv nroot (inv_inner l).
+    waiters_inv γ.(metadata_waiters) sz ∗
+    inv nroot (inv_inner 𝑡).
   #[local] Instance : CustomIpat "inv" :=
-    " ( %l{}
+    " ( %𝑡{}
       & %γ{}
       & {%Heq{};->}
       & ->
       & #Hmeta{}
-      & #Hl{}_size
-      & #Hl{}_queue
-      & #Hl{}_waiters
+      & #H𝑡{}_size
+      & #H𝑡{}_queue
+      & #H𝑡{}_waiters
       & #Hqueue{}_inv
       & #Hwaiters{}_inv
       & #Hinv{}
@@ -176,9 +178,9 @@ Section ws_hub_fifo_G.
     ".
 
   Definition ws_hub_fifo_model t vs : iProp Σ :=
-    ∃ l γ ws,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ ws,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     mpmc_queue_1_model γ.(metadata_queue) ws ∗
     ⌜consistent vs ws⌝ ∗
     emptiness_auth γ vs.
@@ -195,13 +197,13 @@ Section ws_hub_fifo_G.
     ".
 
   Definition ws_hub_fifo_owner t i status empty : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     owner γ i ∗
     emptiness_at γ i empty.
   #[local] Instance : CustomIpat "owner" :=
-    " ( %l{;_}
+    " ( %𝑡{;_}
       & %γ{;_}
       & %Heq{}
       & #Hmeta_{}
@@ -226,7 +228,7 @@ Section ws_hub_fifo_G.
     ⊢ |==>
       ∃ γ_owners,
       [∗ list] i ∈ seq 0 sz,
-        owner' γ_owners i.
+        owner' γ_owners sz i.
   Proof.
     iAssert (
       [∗ list] _ ∈ seq 0 sz,
@@ -238,11 +240,21 @@ Section ws_hub_fifo_G.
       iApply excl_alloc.
     }
     iMod (big_sepL_bupd with "H") as "H".
-    iDestruct (big_sepL_exists with "H") as "(%γ_owners & _ & H)".
+    iDestruct (big_sepL_exists with "H") as "(%γ_owners & %Hlength & H)".
+    iDestruct (big_sepL2_intro (λ _ _ _, ⌜length γ_owners = sz⌝)%I (seq 0 sz) γ_owners with "[%]") as "Hlength". 1: done.
+    { simpl_length in Hlength. naive_solver. }
+    iDestruct (big_sepL2_sep_2 with "Hlength H") as "H".
     iDestruct (big_sepL2_retract_r with "H") as "(_ & H)".
     iDestruct (big_sepL_seq_index_2 with "H") as "H".
     { simpl_length. }
     iSteps.
+  Qed.
+  #[local] Lemma owner_valid γ i :
+    owner γ i ⊢
+    ⌜i < γ.(metadata_size)⌝.
+  Proof.
+    iIntros "(:owner_)". iPureIntro.
+    rewrite -Hlength. eapply lookup_lt_Some => //.
   Qed.
   #[local] Lemma owner_exclusive γ i :
     owner γ i -∗
@@ -265,6 +277,15 @@ Section ws_hub_fifo_G.
     iMod ghost_list_alloc as "(%γ_emptiness & $ & Hats)".
     iDestruct (big_sepL_replicate_1 with "Hats") as "$".
     iSteps. iPureIntro. simpl_length.
+  Qed.
+  #[local] Lemma emptiness_at_valid γ vs i empty :
+    emptiness_auth γ vs -∗
+    emptiness_at γ i empty -∗
+    ⌜i < γ.(metadata_size)⌝.
+  Proof.
+    iIntros "(:emptiness_auth) Hat".
+    iDestruct (ghost_list_lookup with "Hauth Hat") as %Hi%lookup_lt_Some.
+    iSteps.
   Qed.
   #[local] Lemma emptiness_empty γ vs :
     emptiness_auth γ vs -∗
@@ -321,7 +342,7 @@ Section ws_hub_fifo_G.
     ⌜sz1 = sz2⌝.
   Proof.
     iIntros "(:inv =1) (:inv =2)". simplify.
-    iDestruct (pointsto_agree with "Hl1_size Hl2_size") as %[=].
+    iDestruct (pointsto_agree with "H𝑡1_size H𝑡2_size") as %[=].
     iSteps.
   Qed.
 
@@ -333,6 +354,16 @@ Section ws_hub_fifo_G.
     iIntros "(:owner =1) (:owner =2)". simplify.
     iDestruct (meta_agree with "Hmeta_1 Hmeta_2") as %->.
     iApply (owner_exclusive with "Howner_1 Howner_2").
+  Qed.
+
+  Lemma ws_hub_fifo_inv_owner t ι sz i status empty :
+    ws_hub_fifo_inv t ι sz -∗
+    ws_hub_fifo_owner t i status empty -∗
+    ⌜i < sz⌝.
+  Proof.
+    iIntros "(:inv) (:owner)". simplify.
+    iDestruct (meta_agree with "Hmeta Hmeta_") as %<-.
+    iApply (owner_valid with "Howner").
   Qed.
 
   Lemma ws_hub_fifo_model_empty t ι sz vs :
@@ -370,12 +401,12 @@ Section ws_hub_fifo_G.
     iIntros "%Hsz %Φ _ HΦ".
 
     wp_rec.
-    wp_apply+ (waiters_create𑁒spec with "[//]") as (waiters) "#Hwaiters_inv".
+    wp_apply+ (waiters_create𑁒spec with "[//]") as (waiters) "#Hwaiters_inv". 1: done.
     wp_apply (mpmc_queue_1_create𑁒spec with "[//]") as (queue) "(#Hqueue_inv & Hqueue_model)".
-    wp_block l as "Hmeta" "(Hl_size & Hl_queue & Hl_waiters & Hl_num_active & _)".
-    iMod (pointsto_persist with "Hl_size") as "#Hl_size".
-    iMod (pointsto_persist with "Hl_queue") as "#Hl_queue".
-    iMod (pointsto_persist with "Hl_waiters") as "#Hl_waiters".
+    wp_block 𝑡 as "Hmeta" "(H𝑡_size & H𝑡_queue & H𝑡_waiters & H𝑡_num_active & _)".
+    iMod (pointsto_persist with "H𝑡_size") as "#H𝑡_size".
+    iMod (pointsto_persist with "H𝑡_queue") as "#H𝑡_queue".
+    iMod (pointsto_persist with "H𝑡_waiters") as "#H𝑡_waiters".
 
     iMod owner_alloc as "(%γ_owners & Howners)".
     iMod (emptiness_alloc ₊sz) as "(%γ_emptiness & Hemptiness_auth & Hemptiness_ats)".
@@ -391,8 +422,8 @@ Section ws_hub_fifo_G.
     iMod (meta_set γ with "Hmeta") as "#Hmeta"; first done.
 
     iApply "HΦ".
-    iSplitL "Hl_num_active".
-    { iExists l, γ. iSteps. }
+    iSplitL "H𝑡_num_active".
+    { iExists 𝑡, γ. iSteps. }
     iSplitL "Hqueue_model Hemptiness_auth".
     { iSteps. }
     iDestruct (big_sepL_sep_2 with "Howners Hemptiness_ats") as "Howners".
@@ -504,7 +535,7 @@ Section ws_hub_fifo_G.
     iIntros "%Φ (:inv) HΦ".
 
     wp_rec. wp_load.
-    wp_apply (waiters_notify𑁒spec with "Hwaiters_inv HΦ").
+    wp_apply (waiters_notify_one𑁒spec with "Hwaiters_inv HΦ").
   Qed.
 
   #[local] Lemma ws_hub_fifo_notify_all𑁒spec t ι sz :
@@ -519,10 +550,8 @@ Section ws_hub_fifo_G.
   Proof.
     iIntros "%Φ (:inv) HΦ".
 
-    wp_rec.
-    wp_apply (ws_hub_fifo_size𑁒spec) as "_"; first iSteps.
-    wp_load.
-    wp_apply (waiters_notify_many𑁒spec with "Hwaiters_inv HΦ"); first lia.
+    wp_rec. wp_load.
+    wp_apply (waiters_notify_all𑁒spec with "Hwaiters_inv HΦ").
   Qed.
 
   Lemma ws_hub_fifo_push𑁒spec t ι sz i i_ empty v :
@@ -611,7 +640,7 @@ Section ws_hub_fifo_G.
         | None =>
             True
         | Some (i, empty) =>
-            ws_hub_fifo_owner #l i Nonblocked Empty
+            ws_hub_fifo_owner #𝑡 i Nonblocked Empty
         end
       )%I with "[> Hemptiness_auth Howner]" as "(Hemptiness_auth & Howner)".
       { destruct owner as [(i, empty) |]; last iSteps.
@@ -803,13 +832,14 @@ Section ws_hub_fifo_G.
     iApply ("HΦ" with "[$Howner $H]").
   Qed.
 
-  #[local] Lemma ws_hub_fifo_steal₀𑁒spec t ι sz :
+  #[local] Lemma ws_hub_fifo_steal₀𑁒spec t ι (sz : nat) i :
+    (0 ≤ i < sz)%Z →
     <<<
       ws_hub_fifo_inv t ι sz
     | ∀∀ vs,
       ws_hub_fifo_model t vs
     >>>
-      ws_hub_fifo_steal₀ t @ ↑ι
+      ws_hub_fifo_steal₀ t #i @ ↑ι
     <<<
       ∃∃ o,
       match o with
@@ -824,13 +854,13 @@ Section ws_hub_fifo_G.
       True
     >>>.
   Proof.
-    iIntros "%Φ (:inv) HΦ".
+    iIntros "%Hi %Φ (:inv) HΦ".
 
     iLöb as "HLöb".
 
     wp_rec. wp_load.
-    wp_apply+ (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as (waiter) "Hwaiter".
-    wp_apply+ ws_hub_fifo_closed𑁒spec as ([]) "_"; first iSteps.
+    wp_apply+ (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as "_". 1: done.
+    wp_apply+ ws_hub_fifo_closed𑁒spec as ([]) "_". 1: iSteps.
 
     - wp_apply+ ws_hub_fifo_notify_all𑁒spec as "_"; first iSteps.
       wp_pures.
@@ -843,10 +873,11 @@ Section ws_hub_fifo_G.
       wp_apply+ (mpmc_queue_1_is_empty𑁒spec' with "Hqueue_inv") as (b) "_".
 
       wp_bind (if: _ then _ else _)%E.
-      wp_apply (wp_wand itype_unit with "[Hwaiter]") as (res) "->".
+      wp_apply (wp_wand itype_unit) as (res) "->".
       { destruct b; wp_pures.
-        1: wp_apply (waiters_commit_wait𑁒spec with "[$Hwaiters_inv $Hwaiter]").
-        2: wp_apply (waiters_cancel_wait𑁒spec with "[$Hwaiters_inv $Hwaiter]").
+        all: wp_load.
+        1: wp_apply (waiters_commit_wait𑁒spec with "Hwaiters_inv"); first done.
+        2: wp_apply (waiters_cancel_wait𑁒spec with "Hwaiters_inv"); first done.
         all: iSteps.
       }
 
@@ -887,10 +918,11 @@ Section ws_hub_fifo_G.
     >>>.
   Proof.
     iIntros (-> Hmax_round_noyield Hmax_round_yield) "%Φ (#Hinv & Howner) HΦ".
+    iDestruct (ws_hub_fifo_inv_owner with "Hinv Howner") as %Hi.
 
     wp_rec.
     wp_apply+ (ws_hub_fifo_begin_inactive𑁒spec with "Hinv") as "_".
-    wp_apply+ (ws_hub_fifo_steal₀𑁒spec with "Hinv").
+    wp_apply+ (ws_hub_fifo_steal₀𑁒spec with "Hinv"). 1: lia.
     iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ HP".
     iApply ("HΦ" with "[$Howner $HP]").
   Qed.

--- a/theories/zoo_parabs/ws_hub_fifo__code.v
+++ b/theories/zoo_parabs/ws_hub_fifo__code.v
@@ -16,7 +16,7 @@ From zoo Require Import
 
 Definition ws_hub_fifo_create : val :=
   fun: "sz" =>
-    { "sz", mpmc_queue_1_create (), waiters_create (), "sz" + 1 }.
+    { "sz", mpmc_queue_1_create (), waiters_create "sz", "sz" + 1 }.
 
 Definition ws_hub_fifo_size : val :=
   fun: "t" =>
@@ -46,11 +46,11 @@ Definition ws_hub_fifo_closed : val :=
 
 Definition ws_hub_fifo_notify : val :=
   fun: "t" =>
-    waiters_notify "t".{waiters}.
+    waiters_notify_one "t".{waiters}.
 
 Definition ws_hub_fifo_notify_all : val :=
   fun: "t" =>
-    waiters_notify_many "t".{waiters} (ws_hub_fifo_size "t").
+    waiters_notify_all "t".{waiters}.
 
 Definition ws_hub_fifo_push : val :=
   fun: "t" "_i" "v" =>
@@ -84,31 +84,30 @@ Definition ws_hub_fifo_steal_until : val :=
     ws_hub_fifo_steal_until₀ "t" "pred".
 
 Definition ws_hub_fifo_steal₀ : val :=
-  rec: "steal" "t" =>
-    let: "waiters" := "t".{waiters} in
-    let: "waiter" := waiters_prepare_wait "waiters" in
+  rec: "steal" "t" "i" =>
+    waiters_prepare_wait "t".{waiters} "i" ;;
     if: ws_hub_fifo_closed "t" then (
       ws_hub_fifo_notify_all "t" ;;
       §None
     ) else (
       if: mpmc_queue_1_is_empty "t".{queue} then (
-        waiters_commit_wait "waiters" "waiter"
+        waiters_commit_wait "t".{waiters} "i"
       ) else (
-        waiters_cancel_wait "waiters" "waiter"
+        waiters_cancel_wait "t".{waiters} "i"
       ) ;;
       match: ws_hub_fifo_pop' "t" with
       | Some <> as "res" =>
           ws_hub_fifo_end_inactive "t" ;;
           "res"
       | None =>
-          "steal" "t"
+          "steal" "t" "i"
       end
     ).
 
 Definition ws_hub_fifo_steal : val :=
-  fun: "t" "_i" <> <> =>
+  fun: "t" "i" <> <> =>
     ws_hub_fifo_begin_inactive "t" ;;
-    ws_hub_fifo_steal₀ "t".
+    ws_hub_fifo_steal₀ "t" "i".
 
 Definition ws_hub_fifo_close : val :=
   ws_hub_fifo_begin_inactive.

--- a/theories/zoo_parabs/ws_hub_std.v
+++ b/theories/zoo_parabs/ws_hub_std.v
@@ -29,7 +29,7 @@ From zoo Require Import
 
 Implicit Types b yield closed : bool.
 Implicit Types num_active : Z.
-Implicit Types l : location.
+Implicit Types 𝑡 : location.
 Implicit Types v t pred : val.
 Implicit Types vs : gmultiset val.
 Implicit Types ws us : list val.
@@ -155,35 +155,35 @@ Section ws_hub_std_G.
     solve_countable.
   Qed.
 
-  #[local] Definition inv_inner l : iProp Σ :=
+  #[local] Definition inv_inner 𝑡 : iProp Σ :=
     ∃ num_active,
-    l.[num_active] ↦ #num_active.
+    𝑡.[num_active] ↦ #num_active.
   #[local] Instance : CustomIpat "inv_inner" :=
     " ( %num_active
-      & Hl_num_active
+      & H𝑡_num_active
       )
     ".
   Definition ws_hub_std_inv t ι sz : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     ⌜sz = γ.(metadata_size)⌝ ∗
-    l.[queues] ↦□ γ.(metadata_queues) ∗
-    l.[rounds] ↦□ γ.(metadata_rounds) ∗
-    l.[waiters] ↦□ γ.(metadata_waiters) ∗
+    𝑡.[queues] ↦□ γ.(metadata_queues) ∗
+    𝑡.[rounds] ↦□ γ.(metadata_rounds) ∗
+    𝑡.[waiters] ↦□ γ.(metadata_waiters) ∗
     ws_deques_public_inv γ.(metadata_queues) ι γ.(metadata_size) ∗
     array_inv γ.(metadata_rounds) γ.(metadata_size) ∗
-    waiters_inv γ.(metadata_waiters) ∗
-    inv nroot (inv_inner l).
+    waiters_inv γ.(metadata_waiters) sz ∗
+    inv nroot (inv_inner 𝑡).
   #[local] Instance : CustomIpat "inv" :=
-    " ( %l{}
+    " ( %𝑡{}
       & %γ{}
       & {%Heq{};->}
       & #Hmeta{}
       & ->
-      & #Hl{}_queues
-      & #Hl{}_rounds
-      & #Hl{}_waiters
+      & #H𝑡{}_queues
+      & #H𝑡{}_rounds
+      & #H𝑡{}_waiters
       & #Hqueues{}_inv
       & #Hrounds{}_inv
       & #Hwaiters{}_inv
@@ -192,13 +192,13 @@ Section ws_hub_std_G.
     ".
 
   Definition ws_hub_std_model t vs : iProp Σ :=
-    ∃ l γ vss,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ vss,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     ws_deques_public_model γ.(metadata_queues) vss ∗
     ⌜consistent vs vss⌝.
   #[local] Instance : CustomIpat "model" :=
-    " ( %l_
+    " ( %𝑡_
       & %γ_
       & %vss
       & %Heq
@@ -209,15 +209,15 @@ Section ws_hub_std_G.
     ".
 
   Definition ws_hub_std_owner t i status empty : iProp Σ :=
-    ∃ l γ ws round n,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ ws round n,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     ws_deques_public_owner γ.(metadata_queues) i status ws ∗
     ⌜empty = Empty → ws = []⌝ ∗
     array_slice γ.(metadata_rounds) i DfracDiscarded [round] ∗
     random_round_model' round (γ.(metadata_size) - 1) n.
   #[local] Instance : CustomIpat "owner" :=
-    " ( %l{;_}
+    " ( %𝑡{;_}
       & %γ{;_}
       & %ws{}
       & %round{}
@@ -263,6 +263,16 @@ Section ws_hub_std_G.
     iApply (ws_deques_public_owner_exclusive with "Hqueues_owner1 Hqueues_owner2").
   Qed.
 
+  Lemma ws_hub_std_inv_owner t ι sz i status empty :
+    ws_hub_std_inv t ι sz -∗
+    ws_hub_std_owner t i status empty -∗
+    ⌜i < sz⌝.
+  Proof.
+    iIntros "(:inv) (:owner)". simplify.
+    iDestruct (meta_agree with "Hmeta Hmeta_") as %<-.
+    iApply (ws_deques_public_inv_owner with "Hqueues_inv Hqueues_owner").
+  Qed.
+
   Lemma ws_hub_std_model_empty t ι sz vs :
     ws_hub_std_inv t ι sz -∗
     ws_hub_std_model t vs -∗
@@ -304,7 +314,7 @@ Section ws_hub_std_G.
 
     wp_rec.
 
-    wp_apply+ (waiters_create𑁒spec with "[//]") as (waiters) "#Hwaiters_inv".
+    wp_apply+ (waiters_create𑁒spec with "[//]") as (waiters) "#Hwaiters_inv". 1: done.
 
     wp_apply+ (array_unsafe_init𑁒spec_disentangled (λ _ round, random_round_model' round (₊sz - 1) (₊sz - 1))) as (v_rounds rounds) "(%Hrounds & Hrounds_model & Hrounds)"; first done.
     { iIntros "!> %i %Hi".
@@ -318,10 +328,10 @@ Section ws_hub_std_G.
 
     wp_apply+ (ws_deques_public_create𑁒spec with "[//]") as (queues) "(#Hqueues_inv & Hqueues_model & Hqueues_owner)"; first done.
 
-    wp_block l as "Hmeta" "(Hl_queues & Hl_rounds & Hl_waiters & Hl_num_active & _)".
-    iMod (pointsto_persist with "Hl_queues") as "#Hl_queues".
-    iMod (pointsto_persist with "Hl_rounds") as "#Hl_rounds".
-    iMod (pointsto_persist with "Hl_waiters") as "#Hl_waiters".
+    wp_block 𝑡 as "Hmeta" "(H𝑡_queues & H𝑡_rounds & H𝑡_waiters & H𝑡_num_active & _)".
+    iMod (pointsto_persist with "H𝑡_queues") as "#H𝑡_queues".
+    iMod (pointsto_persist with "H𝑡_rounds") as "#H𝑡_rounds".
+    iMod (pointsto_persist with "H𝑡_waiters") as "#H𝑡_waiters".
 
     pose γ := {|
       metadata_size := ₊sz ;
@@ -333,7 +343,7 @@ Section ws_hub_std_G.
     iMod (meta_set γ with "Hmeta") as "#Hmeta"; first done.
 
     iApply "HΦ".
-    iSplitL "Hl_num_active"; iSteps.
+    iSplitL "H𝑡_num_active"; iSteps.
     - iPureIntro. apply consistent_alloc.
     - iMod (array_model_persist with "Hrounds_model") as "Hrounds_model".
       iDestruct (array_model_atomize with "Hrounds_model") as "(_ & Hrounds_model)".
@@ -493,7 +503,7 @@ Section ws_hub_std_G.
     iIntros "%Φ (:inv) HΦ".
 
     wp_rec. wp_load.
-    wp_apply (waiters_notify𑁒spec with "Hwaiters_inv HΦ").
+    wp_apply (waiters_notify_one𑁒spec with "Hwaiters_inv HΦ").
   Qed.
 
   #[local] Lemma ws_hub_std_notify_all𑁒spec t ι sz :
@@ -508,10 +518,8 @@ Section ws_hub_std_G.
   Proof.
     iIntros "%Φ (:inv) HΦ".
 
-    wp_rec.
-    wp_apply (ws_hub_std_size𑁒spec) as "_"; first iSteps.
-    wp_load.
-    wp_apply (waiters_notify_many𑁒spec with "Hwaiters_inv HΦ"); first lia.
+    wp_rec. wp_load.
+    wp_apply (waiters_notify_all𑁒spec with "Hwaiters_inv HΦ").
   Qed.
 
   Lemma ws_hub_std_push𑁒spec t ι sz i i_ empty v :
@@ -946,6 +954,7 @@ Section ws_hub_std_G.
     >>>.
   Proof.
     iIntros (->) "%Hmax_round_noyield %Hmax_round_yield %Φ (#Hinv & Howner) HΦ".
+    iDestruct (ws_hub_std_inv_owner with "Hinv Howner") as %Hi.
 
     iLöb as "HLöb".
 
@@ -960,38 +969,40 @@ Section ws_hub_std_G.
     iAaccIntro with "Hmodel"; first iSteps. iIntros ([| | v]) "Hmodel !>".
 
     - iLeft. iFrame.
-      iIntros "HΦ !> (Howner & _) {%}".
+      iIntros "HΦ !> (Howner & _) {%- Hi}".
 
       iDestruct "Hinv" as "(:inv)".
 
       wp_load.
-      wp_apply+ (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as (waiter) "Hwaiter".
+      wp_apply (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as "_". 1: lia.
 
-      awp_apply+ (ws_hub_std_try_steal_once𑁒spec with "[$Howner]") without "Hwaiter"; [done.. | iSteps |].
+      awp_apply+ (ws_hub_std_try_steal_once𑁒spec with "[$Howner]"). 1: done. 1: iSteps.
       iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
       iAaccIntro with "Hmodel"; first iSteps. iIntros ([v |]) "Hmodel !>".
 
       + iDestruct "Hmodel" as "(%vs' & -> & Hmodel)".
         iRight. iExists (Some v).
         iSplitL "Hmodel". { iFrameSteps. }
-        iIntros "HΦ !> Howner Hwaiter {%}".
+        iIntros "HΦ !> Howner {%- Hi}".
 
-        wp_apply+ (waiters_cancel_wait𑁒spec with "[$Hwaiters_inv $Hwaiter]") as "_".
+        wp_load.
+        wp_apply (waiters_cancel_wait𑁒spec with "Hwaiters_inv") as "_". 1: lia.
         wp_apply+ (ws_hub_std_unblock𑁒spec with "[$Howner]") as "Howner". 1: done. 1: iSteps.
         wp_pures.
         iApply ("HΦ" with "Howner").
 
       + iLeft. iFrame.
-        iIntros "HΦ !> Howner Hwaiter {%}".
+        iIntros "HΦ !> Howner {%- Hi}".
 
-        wp_apply+ ws_hub_std_closed𑁒spec as ([]) "_"; first iSteps.
+        wp_apply+ ws_hub_std_closed𑁒spec as ([]) "_". 1: iSteps.
 
         * wp_apply+ ws_hub_std_notify_all𑁒spec as "_". 1: iSteps.
           wp_pures.
           iMod "HΦ" as "(%vss & Hmodel & _ & HΦ)".
           iApply ("HΦ" $! None with "Hmodel Howner").
 
-        * wp_apply+ (waiters_commit_wait𑁒spec with "[$Hwaiters_inv $Hwaiter]") as "_".
+        * wp_load.
+          wp_apply (waiters_commit_wait𑁒spec with "Hwaiters_inv") as "_". 1: lia.
           wp_apply+ ("HLöb" with "Howner HΦ").
 
     - iRight. iExists None. iFrame. iIntros "HΦ !> (Howner & _)".

--- a/theories/zoo_parabs/ws_hub_std__code.v
+++ b/theories/zoo_parabs/ws_hub_std__code.v
@@ -23,7 +23,7 @@ Definition ws_hub_std_create : val :=
       array_unsafe_init
         "sz"
         (fun: <> => random_round_create (int_positive_part ("sz" - 1))),
-      waiters_create (),
+      waiters_create "sz",
       "sz" + 1
     }.
 
@@ -65,11 +65,11 @@ Definition ws_hub_std_closed : val :=
 
 Definition ws_hub_std_notify : val :=
   fun: "t" =>
-    waiters_notify "t".{waiters}.
+    waiters_notify_one "t".{waiters}.
 
 Definition ws_hub_std_notify_all : val :=
   fun: "t" =>
-    waiters_notify_many "t".{waiters} (ws_hub_std_size "t").
+    waiters_notify_all "t".{waiters}.
 
 Definition ws_hub_std_push : val :=
   fun: "t" "i" "v" =>
@@ -170,11 +170,10 @@ Definition ws_hub_std_steal₀ : val :=
         ws_hub_std_notify_all "t" ;;
         §None
     | Nothing =>
-        let: "waiters" := "t".{waiters} in
-        let: "waiter" := waiters_prepare_wait "waiters" in
+        waiters_prepare_wait "t".{waiters} "i" ;;
         match: ws_hub_std_try_steal_once "t" "i" with
         | Some <> as "res" =>
-            waiters_cancel_wait "waiters" "waiter" ;;
+            waiters_cancel_wait "t".{waiters} "i" ;;
             ws_hub_std_unblock "t" "i" ;;
             "res"
         | None =>
@@ -182,7 +181,7 @@ Definition ws_hub_std_steal₀ : val :=
               ws_hub_std_notify_all "t" ;;
               §None
             ) else (
-              waiters_commit_wait "waiters" "waiter" ;;
+              waiters_commit_wait "t".{waiters} "i" ;;
               "steal" "t" "i" "max_round_noyield" "max_round_yield"
             )
         end

--- a/theories/zoo_std/mpsc_waiter.v
+++ b/theories/zoo_std/mpsc_waiter.v
@@ -19,7 +19,7 @@ From zoo Require Import
   options.
 
 Implicit Types b : bool.
-Implicit Types l : location.
+Implicit Types 𝑡 : location.
 
 Class MpscWaiterG Σ `{zoo_G : !ZooG Σ} :=
   { #[local] mpsc_waiter_G_mutex_G :: MutexG Σ
@@ -58,34 +58,34 @@ Section mpsc_waiter_G.
     solve_countable.
   Qed.
 
-  #[local] Definition inv_inner l γ P : iProp Σ :=
+  #[local] Definition inv_inner 𝑡 γ P : iProp Σ :=
     ∃ b,
-    l.[flag] ↦ #b ∗
+    𝑡.[flag] ↦ #b ∗
     if b then
       oneshot_shot γ.(metadata_lstate) () ∗
       (P ∨ excl γ.(metadata_consumer) ())
     else
       oneshot_pending γ.(metadata_lstate) (DfracOwn 1) ().
   Definition mpsc_waiter_inv t P : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
-    l.[mutex] ↦□ γ.(metadata_mutex) ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
+    𝑡.[mutex] ↦□ γ.(metadata_mutex) ∗
     mutex_inv γ.(metadata_mutex) True ∗
-    l.[condition] ↦□ γ.(metadata_condition) ∗
+    𝑡.[condition] ↦□ γ.(metadata_condition) ∗
     condition_inv γ.(metadata_condition) ∗
-    inv nroot (inv_inner l γ P).
+    inv nroot (inv_inner 𝑡 γ P).
 
   Definition mpsc_waiter_consumer t : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     excl γ.(metadata_consumer) ().
 
   Definition mpsc_waiter_notified t : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     oneshot_shot γ.(metadata_lstate) ().
 
   #[global] Instance mpsc_waiter_inv_contractive t :
@@ -131,7 +131,7 @@ Section mpsc_waiter_G.
     mpsc_waiter_consumer t -∗
     False.
   Proof.
-    iIntros "(%l & %γ & -> & #Hmeta & Hconsumer1) (%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer2)". injection Heq as <-.
+    iIntros "(%𝑡 & %γ & -> & #Hmeta & Hconsumer1) (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer2)". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
     iApply (excl_exclusive with "Hconsumer1 Hconsumer2").
   Qed.
@@ -153,9 +153,9 @@ Section mpsc_waiter_G.
     wp_rec.
     wp_apply+ (condition_create𑁒spec with "[//]") as "%cond #Hcondition_inv".
     wp_apply+ (mutex_create𑁒spec True with "[//]") as "%mtx #Hmutex_inv".
-    wp_block l as "Hmeta" "(Hl_mutex & Hl_condition & Hl_flag & _)".
-    iMod (pointsto_persist with "Hl_mutex") as "Hl_mutex".
-    iMod (pointsto_persist with "Hl_condition") as "Hl_condition".
+    wp_block 𝑡 as "Hmeta" "(H𝑡_mutex & H𝑡_condition & H𝑡_flag & _)".
+    iMod (pointsto_persist with "H𝑡_mutex") as "H𝑡_mutex".
+    iMod (pointsto_persist with "H𝑡_condition") as "H𝑡_condition".
 
     iMod (oneshot_alloc ()) as "(%γ_lstate & Hpending)".
 
@@ -184,16 +184,15 @@ Section mpsc_waiter_G.
       mpsc_waiter_notified t
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & HP) HΦ".
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & HP) HΦ".
 
-    wp_rec.
-    wp_pures.
+    wp_rec. wp_pures.
 
     wp_bind (_.{flag})%E.
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; first iSteps.
-    iSplitR "HP HΦ"; first iSteps.
+    iSplitR "HP HΦ". { iFrameSteps. }
     iModIntro.
 
     wp_load.
@@ -207,16 +206,16 @@ Section mpsc_waiter_G.
     wp_pures.
 
     wp_bind (_.{flag})%E.
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; first iSteps.
-    iSplitR "HP Hmutex_locked"; first iSteps.
+    iSplitR "HP Hmutex_locked". { iFrameSteps. }
     iModIntro.
 
     wp_pures.
 
     wp_bind (_ <-{flag} _)%E.
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_store.
     destruct b; first iSteps.
     iMod (oneshot_update_shot with "Hb") as "#Hshot".
@@ -238,13 +237,12 @@ Section mpsc_waiter_G.
         mpsc_waiter_consumer t
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & (%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer)) HΦ". injection Heq as <-.
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer)) HΦ". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
 
-    wp_rec.
-    wp_pures.
+    wp_rec. wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last iSteps.
     iDestruct "Hb" as "(Hshot & [HP | Hconsumer'])"; last first.
@@ -263,14 +261,13 @@ Section mpsc_waiter_G.
       P
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & (%l_1 & %γ_1 & %Heq1 & Hmeta_1 & Hconsumer) & (%l_2 & %γ_2 & %Heq2 & Hmeta_2 & #Hshot)) HΦ". injection Heq1 as <-. injection Heq2 as <-.
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & (%𝑡1 & %γ1 & %Heq1 & Hmeta_1 & Hconsumer) & (%𝑡2 & %γ2 & %Heq2 & Hmeta_2 & #Hshot)) HΦ". injection Heq1 as <-. injection Heq2 as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_1") as %<-. iClear "Hmeta_1".
     iDestruct (meta_agree with "Hmeta Hmeta_2") as %<-. iClear "Hmeta_2".
 
-    wp_rec.
-    wp_pures.
+    wp_rec. wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last first.
     { iDestruct (oneshot_pending_shot with "Hb Hshot") as %[]. }
@@ -295,8 +292,8 @@ Section mpsc_waiter_G.
     wp_rec.
     wp_apply (mpsc_waiter_try_wait𑁒spec with "[$Hinv $Hconsumer]") as ([]) "Hconsumer"; first iSteps.
 
-    iDestruct "Hinv" as "(%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv)".
-    iDestruct "Hconsumer" as "(%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer)". injection Heq as <-.
+    iDestruct "Hinv" as "(%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv)".
+    iDestruct "Hconsumer" as "(%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer)". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
 
     do 2 wp_load.
@@ -317,7 +314,7 @@ Section mpsc_waiter_G.
     iIntros "!> Hmutex_locked _ Hconsumer".
     wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last iSteps.
     iDestruct "Hb" as "(Hshot & [HP | Hconsumer'])"; last first.

--- a/theories/zoo_std/spsc_waiter.v
+++ b/theories/zoo_std/spsc_waiter.v
@@ -19,7 +19,7 @@ From zoo Require Import
   options.
 
 Implicit Types b : bool.
-Implicit Types l : location.
+Implicit Types 𝑡 : location.
 
 Class SpscWaiterG Σ `{zoo_G : !ZooG Σ} :=
   { #[local] spsc_waiter_G_mutex_G :: MutexG Σ
@@ -58,40 +58,40 @@ Section spsc_waiter_G.
     solve_countable.
   Qed.
 
-  #[local] Definition inv_inner l γ P : iProp Σ :=
+  #[local] Definition inv_inner 𝑡 γ P : iProp Σ :=
     ∃ b,
-    l.[flag] ↦ #b ∗
+    𝑡.[flag] ↦ #b ∗
     if b then
       oneshot_shot γ.(metadata_lstate) () ∗
       (P ∨ excl γ.(metadata_consumer) ())
     else
       oneshot_pending γ.(metadata_lstate) (DfracOwn (1/3)) ().
   Definition spsc_waiter_inv t P : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
-    l.[mutex] ↦□ γ.(metadata_mutex) ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
+    𝑡.[mutex] ↦□ γ.(metadata_mutex) ∗
     mutex_inv γ.(metadata_mutex) True ∗
-    l.[condition] ↦□ γ.(metadata_condition) ∗
+    𝑡.[condition] ↦□ γ.(metadata_condition) ∗
     condition_inv γ.(metadata_condition) ∗
-    inv nroot (inv_inner l γ P).
+    inv nroot (inv_inner 𝑡 γ P).
 
   Definition spsc_waiter_producer t : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     oneshot_pending γ.(metadata_lstate) (DfracOwn (2/3)) ().
 
   Definition spsc_waiter_consumer t : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     excl γ.(metadata_consumer) ().
 
   Definition spsc_waiter_notified t : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     oneshot_shot γ.(metadata_lstate) ().
 
   #[global] Instance spsc_waiter_inv_contractive t :
@@ -142,7 +142,7 @@ Section spsc_waiter_G.
     spsc_waiter_producer t -∗
     False.
   Proof.
-    iIntros "(%l & %γ & -> & #Hmeta & Hpending1) (%l_ & %γ_ & %Heq & Hmeta_ & Hpending2)". injection Heq as <-.
+    iIntros "(%𝑡 & %γ & -> & #Hmeta & Hpending1) (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hpending2)". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
     iDestruct (oneshot_pending_valid_2 with "Hpending1 Hpending2") as %(? & _). done.
   Qed.
@@ -152,7 +152,7 @@ Section spsc_waiter_G.
     spsc_waiter_consumer t -∗
     False.
   Proof.
-    iIntros "(%l & %γ & -> & #Hmeta & Hconsumer1) (%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer2)". injection Heq as <-.
+    iIntros "(%𝑡 & %γ & -> & #Hmeta & Hconsumer1) (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer2)". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
     iApply (excl_exclusive with "Hconsumer1 Hconsumer2").
   Qed.
@@ -175,9 +175,9 @@ Section spsc_waiter_G.
     wp_rec.
     wp_apply+ (condition_create𑁒spec with "[//]") as "%cond #Hcondition_inv".
     wp_apply+ (mutex_create𑁒spec True with "[//]") as "%mtx #Hmutex_inv".
-    wp_block l as "Hmeta" "(Hl_mutex & Hl_condition & Hl_flag & _)".
-    iMod (pointsto_persist with "Hl_mutex") as "Hl_mutex".
-    iMod (pointsto_persist with "Hl_condition") as "Hl_condition".
+    wp_block 𝑡 as "Hmeta" "(H𝑡_mutex & H𝑡_condition & H𝑡_flag & _)".
+    iMod (pointsto_persist with "H𝑡_mutex") as "H𝑡_mutex".
+    iMod (pointsto_persist with "H𝑡_condition") as "H𝑡_condition".
 
     iMod (oneshot_alloc ()) as "(%γ_lstate & Hpending)".
     iEval (assert (1 = 2/3 + 1/3)%Qp as -> by compute_done) in "Hpending".
@@ -208,7 +208,7 @@ Section spsc_waiter_G.
       spsc_waiter_notified t
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & (%l_ & %γ_ & %Heq & Hmeta_ & Hpending) & HP) HΦ". injection Heq as <-.
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hpending) & HP) HΦ". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
 
     wp_rec. wp_load.
@@ -219,7 +219,7 @@ Section spsc_waiter_G.
     { iIntros "Hmutex_locked _".
       wp_pures.
       wp_bind (_ <-{flag} _)%E.
-      iInv "Hinv" as "(%b & Hl_flag & Hb)".
+      iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
       wp_store.
       destruct b.
       { iDestruct "Hb" as "(Hshot & _)".
@@ -250,13 +250,12 @@ Section spsc_waiter_G.
         spsc_waiter_consumer t
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & (%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer)) HΦ". injection Heq as <-.
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer)) HΦ". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
 
-    wp_rec.
-    wp_pures.
+    wp_rec. wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last iSteps.
     iDestruct "Hb" as "(Hshot & [HP | Hconsumer'])"; last first.
@@ -275,14 +274,13 @@ Section spsc_waiter_G.
       P
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & (%l_1 & %γ_1 & %Heq1 & Hmeta_1 & Hconsumer) & (%l_2 & %γ_2 & %Heq2 & Hmeta_2 & #Hshot)) HΦ". injection Heq1 as <-. injection Heq2 as <-.
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & (%𝑡1 & %γ1 & %Heq1 & Hmeta_1 & Hconsumer) & (%𝑡2 & %γ2 & %Heq2 & Hmeta_2 & #Hshot)) HΦ". injection Heq1 as <-. injection Heq2 as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_1") as %<-. iClear "Hmeta_1".
     iDestruct (meta_agree with "Hmeta Hmeta_2") as %<-. iClear "Hmeta_2".
 
-    wp_rec.
-    wp_pures.
+    wp_rec. wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last first.
     { iDestruct (oneshot_pending_shot with "Hb Hshot") as %[]. }
@@ -307,8 +305,8 @@ Section spsc_waiter_G.
     wp_rec.
     wp_apply (spsc_waiter_try_wait𑁒spec with "[$Hinv $Hconsumer]") as ([]) "Hconsumer"; first iSteps.
 
-    iDestruct "Hinv" as "(%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv)".
-    iDestruct "Hconsumer" as "(%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer)". injection Heq as <-.
+    iDestruct "Hinv" as "(%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv)".
+    iDestruct "Hconsumer" as "(%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer)". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
 
     do 2 wp_load.
@@ -329,7 +327,7 @@ Section spsc_waiter_G.
     iIntros "!> Hmutex_locked _ Hconsumer".
     wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last iSteps.
     iDestruct "Hb" as "(Hshot & [HP | Hconsumer'])"; last first.


### PR DESCRIPTION
This PR reimplements `Parabs.Waiters` so that waiters are recycled: instead of creating a new waiter before sleeping, an idle worker now reuses its associated waiter. It is based on https://github.com/clef-men/zoo/pull/14. (To make things easier, I decided to split @gasche's PR into two parts. This is the first part.)

The implementation of a waiter entity (`Parabs.Waiter`) is basically the same as before (`Zoo_std.Mpsc_flag`) except the flag can now be reset to `false` (through `Parabs.Waiter.prepare_wait`). However, there are two subtle points.

(1) Due to relaxed memory, `Parabs.Waiter.notify` (called in `Parabs.Waiters.notify`) may return `true` even though the associated worker just called `Parabs.Waiter.cancel_wait`. In this case, `Parabs.Waiter.notify` actually notifies the condition variable, which may be considered useless but is acceptable is practice (the crucial point is to avoid missing a notification).

(2) One may wonder whether, due to relaxed memory, it may happen that `Parabs.Waiter.notify` observes the flag to be `true` — and therefore does not notify the condition variable — even though the "corresponding" `Parabs.Waiter.prepare_wait` reset it to `false`. This should not happen since (a) the "corresponding" `Parabs.Waiter.prepare_wait` is called in `Parabs.Waiters.prepare_wait`, just before `Zoo_saturn.Mpmc_queue_1.push`, (b) `Parabs.Waiter.notify` is called in `Parabs.Waiters.notify`, just after `Zoo_saturn.Mpmc_queue_1.pop`, and (c) `Zoo_saturn.Mpmc_queue_1.pop` guarantees synchronization between `pop` and the corresponding `push` (this is not yet proven, as Zoo assumes sequential consistency :wink:).