### PR TITLE
`Parabs` without busy waiting

### DIFF
--- a/_RocqProject
+++ b/_RocqProject
@@ -462,6 +462,10 @@ theories/zoo_parabs/ws_deques_private__types.v
 theories/zoo_parabs/ws_deques_private__code.v
 theories/zoo_parabs/ws_deques_private__opaque.v
 theories/zoo_parabs/ws_deques_private.v
+theories/zoo_parabs/waiter__types.v
+theories/zoo_parabs/waiter__code.v
+theories/zoo_parabs/waiter__opaque.v
+theories/zoo_parabs/waiter.v
 theories/zoo_parabs/waiters__types.v
 theories/zoo_parabs/waiters__code.v
 theories/zoo_parabs/waiters__opaque.v

--- a/lib/examples/vertex_fibonacci.ml
+++ b/lib/examples/vertex_fibonacci.ml
@@ -29,11 +29,11 @@ let main ~num_worker n =
     Vertex.set_task vtx1 (fun ctx -> main ctx vtx1 r n) ;
     Vertex.release ctx vtx1 ;
 
-    let flag = Mpsc_flag.create () in
-    let vtx2 = Vertex.create' (fun _ctx -> Mpsc_flag.set flag) in
+    let ivar = Ivar_3.create () in
+    let vtx2 = Vertex.create' (fun ctx -> Ivar_3.notify ivar ctx) in
     Vertex.precede vtx1 vtx2 ;
     Vertex.release ctx vtx2 ;
 
-    Pool.wait_until ctx (fun () -> Mpsc_flag.get flag) ;
+    Pool.wait_ivar ctx ivar ;
     !r
   )

--- a/lib/examples/vertex_simple.ml
+++ b/lib/examples/vertex_simple.ml
@@ -1,10 +1,10 @@
 let main ~num_worker a b c d =
-  let flag = Mpsc_flag.create () in
+  let ivar = Ivar_3.create () in
 
   let vtx_a = Vertex.create' @@ fun _ctx -> a () in
   let vtx_b = Vertex.create' @@ fun _ctx -> b () in
   let vtx_c = Vertex.create' @@ fun _ctx -> c () in
-  let vtx_d = Vertex.create' @@ fun _ctx -> d () ; Mpsc_flag.set flag in
+  let vtx_d = Vertex.create' @@ fun ctx -> d () ; Ivar_3.notify ivar ctx in
 
   Vertex.precede vtx_a vtx_b ;
   Vertex.precede vtx_a vtx_c ;
@@ -16,5 +16,5 @@ let main ~num_worker a b c d =
     Vertex.release ctx vtx_c ;
     Vertex.release ctx vtx_b ;
     Vertex.release ctx vtx_a ;
-    Pool.wait_until ctx (fun () -> Mpsc_flag.get flag)
+    Pool.wait_ivar ctx ivar
   )

--- a/lib/zoo_parabs/future.ml
+++ b/lib/zoo_parabs/future.ml
@@ -14,7 +14,7 @@ let async ctx task =
   t
 
 let wait ctx t =
-  Pool.wait_until ctx (fun () -> Ivar_3.is_set t) ;
+  Pool.wait_ivar ctx t ;
   Ivar_3.get t
 
 let iter ctx t task =

--- a/lib/zoo_parabs/pool.ml
+++ b/lib/zoo_parabs/pool.ml
@@ -34,7 +34,13 @@ let execute ctx job =
   job ctx
 
 let rec worker ctx =
-  match Ws_hub_std.pop_steal ctx.context_hub ctx.context_id ~max_round_noyield ~max_round_yield with
+  match
+    Ws_hub_std.pop_steal
+      ctx.context_hub
+      ctx.context_id
+      ~max_round_noyield
+      ~max_round_yield
+  with
   | None ->
       ()
   | Some job ->
@@ -79,13 +85,37 @@ let size ctx =
 let async ctx task =
   Ws_hub_std.push ctx.context_hub ctx.context_id task
 
-let rec wait_until ctx pred =
-  if not @@ pred () then
-    match Ws_hub_std.pop_steal_until ctx.context_hub ctx.context_id ~max_round_noyield pred with
-    | None ->
-        ()
-    | Some job ->
-        execute ctx job ;
-        wait_until ctx pred
-let wait_while ctx pred =
-  wait_until ctx (fun () -> not @@ pred ())
+let rec wait ctx ~notification ~pred =
+  match
+    Ws_hub_std.pop_steal_until
+      ctx.context_hub
+      ctx.context_id
+      ~max_round_noyield
+      ~max_round_yield
+      ~notification
+      ~pred
+  with
+  | None ->
+      ()
+  | Some job ->
+      execute ctx job ;
+      wait ctx ~notification ~pred
+let wait ctx ~notification ~pred =
+  let notification_registered = ref false in
+  let notification notify =
+    if not !notification_registered then (
+      notification_registered := true ;
+      notification notify
+    )
+  in
+  wait ctx ~notification ~pred
+
+let wait_ivar ctx ivar =
+  wait
+    ctx
+    ~notification:(fun notify ->
+      Ivar_3.wait ivar (fun _ctx _v -> notify ()) |> ignore
+    )
+    ~pred:(fun () ->
+      Ivar_3.is_set ivar
+    )

--- a/lib/zoo_parabs/pool.mli
+++ b/lib/zoo_parabs/pool.mli
@@ -66,11 +66,25 @@ val async :
 (** [async ctx task] schedules the [task] to be executed asynchronously
     by the pool. *)
 
-val wait_until :
-  context -> (unit -> bool) -> unit
-(** [wait_until ctx pred] waits until [pred ()] returns [true],
-    working on other tasks in the meantime. *)
+val wait :
+  context ->
+  notification:((unit -> unit) -> unit) ->
+  pred:(unit -> bool) ->
+  unit
+(** [wait ctx ~notification ~pred] waits until [pred ()] returns [true],
+    working on other tasks in the meantime. If the worker is put
+    to sleep because no other task is available, [notification] will
+    be called with a wakeup callback.
 
-val wait_while :
-  context -> (unit -> bool) -> unit
-(** [wait_while ctx pred] is [wait_until ctx (fun () -> not (pred ()))]. *)
+    We assume that [pred ()] is a cheap and monotonic function:
+    once it returns [true], it will return [true] forever.
+
+    We assume that [notification] will eventually call the wakeup
+    callback if/when [pred ()] changes from [false] to [true]. In
+    particular, [notification] is allowed to drop the callback if it
+    observes that [pred ()] already holds. *)
+
+val wait_ivar :
+  context -> ('a, ('a -> unit) task) Ivar_3.t -> unit
+(** [wait_ivar ctx ivar] waits until [ivar] is set,
+    working on other tasks in the meantime.  *)

--- a/lib/zoo_parabs/waiter.ml
+++ b/lib/zoo_parabs/waiter.ml
@@ -28,7 +28,12 @@ let prepare_wait t =
 
 let cancel_wait t =
   Mutex.protect t.mutex @@ fun () ->
-    t.flag <- true
+    if t.flag then (
+      false
+    ) else (
+      t.flag <- true ;
+      true
+    )
 
 let commit_wait t =
   Mutex.protect t.mutex @@ fun () ->

--- a/lib/zoo_parabs/waiter.ml
+++ b/lib/zoo_parabs/waiter.ml
@@ -11,28 +11,25 @@ let create () =
   }
 
 let notify t =
+  Mutex.lock t.mutex ;
   if t.flag then (
+    Mutex.unlock t.mutex ;
     false
   ) else (
-    Mutex.lock t.mutex ;
-    if t.flag then (
-      Mutex.unlock t.mutex ;
-      false
-    ) else (
-      t.flag <- true ;
-      Mutex.unlock t.mutex ;
-      Condition.notify t.condition ;
-      true
-    )
+    t.flag <- true ;
+    Mutex.unlock t.mutex ;
+    Condition.notify t.condition ;
+    true
   )
 
 let prepare_wait t =
-  t.flag <- false
+  Mutex.protect t.mutex @@ fun () ->
+    t.flag <- false
 
 let cancel_wait t =
-  t.flag <- true
+  Mutex.protect t.mutex @@ fun () ->
+    t.flag <- true
 
 let commit_wait t =
-  if not @@ t.flag then
-    Mutex.protect t.mutex @@ fun () ->
-      Condition.wait_until t.condition t.mutex (fun () -> t.flag)
+  Mutex.protect t.mutex @@ fun () ->
+    Condition.wait_until t.condition t.mutex (fun () -> t.flag)

--- a/lib/zoo_parabs/waiter.ml
+++ b/lib/zoo_parabs/waiter.ml
@@ -1,0 +1,38 @@
+type t =
+  { mutex: Mutex.t
+  ; condition: Condition.t
+  ; mutable flag: bool
+  }
+
+let create () =
+  { mutex= Mutex.create ()
+  ; condition= Condition.create ()
+  ; flag= false
+  }
+
+let notify t =
+  if t.flag then (
+    false
+  ) else (
+    Mutex.lock t.mutex ;
+    if t.flag then (
+      Mutex.unlock t.mutex ;
+      false
+    ) else (
+      t.flag <- true ;
+      Mutex.unlock t.mutex ;
+      Condition.notify t.condition ;
+      true
+    )
+  )
+
+let prepare_wait t =
+  t.flag <- false
+
+let cancel_wait t =
+  t.flag <- true
+
+let commit_wait t =
+  if not @@ t.flag then
+    Mutex.protect t.mutex @@ fun () ->
+      Condition.wait_until t.condition t.mutex (fun () -> t.flag)

--- a/lib/zoo_parabs/waiter.mli
+++ b/lib/zoo_parabs/waiter.mli
@@ -1,0 +1,14 @@
+type t
+
+val create :
+  unit -> t
+
+val notify :
+  t -> bool
+
+val prepare_wait :
+  t -> unit
+val cancel_wait :
+  t -> unit
+val commit_wait :
+  t -> unit

--- a/lib/zoo_parabs/waiter.mli
+++ b/lib/zoo_parabs/waiter.mli
@@ -9,6 +9,6 @@ val notify :
 val prepare_wait :
   t -> unit
 val cancel_wait :
-  t -> unit
+  t -> bool
 val commit_wait :
   t -> unit

--- a/lib/zoo_parabs/waiters.ml
+++ b/lib/zoo_parabs/waiters.ml
@@ -10,7 +10,7 @@ let create sz =
 
 let notify t i =
   let waiter = Array.unsafe_get t.waiters i in
-  Waiter.notify_strong waiter
+  Waiter.notify waiter |> ignore
 
 let rec notify_one t =
   match Mpmc_queue_1.pop t.queue with

--- a/lib/zoo_parabs/waiters.ml
+++ b/lib/zoo_parabs/waiters.ml
@@ -1,35 +1,38 @@
-type waiter =
-  Mpsc_waiter.t
-
 type t =
-  waiter Mpmc_queue_1.t
+  { waiters: Waiter.t array
+  ; queue: Waiter.t Mpmc_queue_1.t
+  }
 
-let create =
-  Mpmc_queue_1.create
+let create sz =
+  { waiters= Array.unsafe_init sz Waiter.create
+  ; queue= Mpmc_queue_1.create ()
+  }
 
-let rec notify' t =
-  match Mpmc_queue_1.pop t with
+let rec notify_one t =
+  match Mpmc_queue_1.pop t.queue with
   | None ->
-      false
+      ()
   | Some waiter ->
-      if Mpsc_waiter.notify waiter then
-        notify' t
-      else
-        true
-let notify t =
-  notify' t |> ignore
-let rec notify_many t n =
-  if 0 < n && notify' t then
-    notify_many t (n - 1)
+      if not @@ Waiter.notify waiter then
+        notify_one t
 
-let prepare_wait t =
-  let waiter = Mpsc_waiter.create () in
-  Mpmc_queue_1.push t waiter ;
-  waiter
+let rec notify_all t =
+  match Mpmc_queue_1.pop t.queue with
+  | None ->
+      ()
+  | Some waiter ->
+      Waiter.notify waiter |> ignore ;
+      notify_all t
 
-let cancel_wait t waiter =
-  if Mpsc_waiter.notify waiter then
-    notify t
+let prepare_wait t i =
+  let waiter = Array.unsafe_get t.waiters i in
+  Waiter.prepare_wait waiter ;
+  Mpmc_queue_1.push t.queue waiter
 
-let commit_wait _t waiter =
-  Mpsc_waiter.wait waiter
+let cancel_wait t i =
+  let waiter = Array.unsafe_get t.waiters i in
+  Waiter.cancel_wait waiter
+
+let commit_wait t i =
+  let waiter = Array.unsafe_get t.waiters i in
+  Waiter.commit_wait waiter

--- a/lib/zoo_parabs/waiters.ml
+++ b/lib/zoo_parabs/waiters.ml
@@ -8,6 +8,10 @@ let create sz =
   ; queue= Mpmc_queue_1.create ()
   }
 
+let notify t i =
+  let waiter = Array.unsafe_get t.waiters i in
+  Waiter.notify_strong waiter
+
 let rec notify_one t =
   match Mpmc_queue_1.pop t.queue with
   | None ->

--- a/lib/zoo_parabs/waiters.mli
+++ b/lib/zoo_parabs/waiters.mli
@@ -1,18 +1,16 @@
 type t
 
-type waiter
-
 val create :
-  unit -> t
+  int -> t
 
-val notify :
+val notify_one :
   t -> unit
-val notify_many :
-  t -> int -> unit
+val notify_all :
+  t -> unit
 
 val prepare_wait :
-  t -> waiter
+  t -> int -> unit
 val cancel_wait :
-  t -> waiter -> unit
+  t -> int -> unit
 val commit_wait :
-  t -> waiter -> unit
+  t -> int -> unit

--- a/lib/zoo_parabs/waiters.mli
+++ b/lib/zoo_parabs/waiters.mli
@@ -13,6 +13,6 @@ val notify_all :
 val prepare_wait :
   t -> int -> unit
 val cancel_wait :
-  t -> int -> unit
+  t -> int -> bool
 val commit_wait :
   t -> int -> unit

--- a/lib/zoo_parabs/waiters.mli
+++ b/lib/zoo_parabs/waiters.mli
@@ -3,6 +3,8 @@ type t
 val create :
   int -> t
 
+val notify :
+  t -> int -> unit
 val notify_one :
   t -> unit
 val notify_all :

--- a/lib/zoo_parabs/ws_hub.ml
+++ b/lib/zoo_parabs/ws_hub.ml
@@ -20,9 +20,19 @@ module type S = sig
     'a t -> int -> 'a option
 
   val steal_until :
-    'a t -> int -> max_round_noyield:int -> (unit -> bool) -> 'a option
+    'a t ->
+    int ->
+    max_round_noyield:int ->
+    max_round_yield:int ->
+    notification:((unit -> unit) -> unit) ->
+    pred:(unit -> bool) ->
+    'a option
   val steal :
-    'a t -> int -> max_round_noyield:int -> max_round_yield:int -> 'a option
+    'a t ->
+    int ->
+    max_round_noyield:int ->
+    max_round_yield:int ->
+    'a option
 
   val closed :
     'a t -> bool
@@ -30,7 +40,17 @@ module type S = sig
     'a t -> unit
 
   val pop_steal_until :
-    'a t -> int -> max_round_noyield:int -> (unit -> bool) -> 'a option
+    'a t ->
+    int ->
+    max_round_noyield:int ->
+    max_round_yield:int ->
+    notification:((unit -> unit) -> unit) ->
+    pred:(unit -> bool) ->
+    'a option
   val pop_steal :
-    'a t -> int -> max_round_noyield:int -> max_round_yield:int -> 'a option
+    'a t ->
+    int ->
+    max_round_noyield:int ->
+    max_round_yield:int ->
+    'a option
 end

--- a/lib/zoo_parabs/ws_hub_fifo.ml
+++ b/lib/zoo_parabs/ws_hub_fifo.ml
@@ -8,7 +8,7 @@ type 'a t =
 let create sz =
   { size= sz
   ; queue= Mpmc_queue_1.create ()
-  ; waiters= Waiters.create ()
+  ; waiters= Waiters.create sz
   ; num_active= sz + 1
   }
 
@@ -29,9 +29,9 @@ let closed t =
   t.num_active == 0
 
 let notify t =
-  Waiters.notify t.waiters
+  Waiters.notify_one t.waiters
 let notify_all t =
-  Waiters.notify_many t.waiters (size t)
+  Waiters.notify_all t.waiters
 
 let push t _i v =
   Mpmc_queue_1.push t.queue v ;
@@ -56,28 +56,27 @@ let rec steal_until t pred =
 let steal_until t _i ~max_round_noyield:_ pred =
   steal_until t pred
 
-let rec steal t =
-  let waiters = t.waiters in
-  let waiter = Waiters.prepare_wait waiters in
+let rec steal t i =
+  Waiters.prepare_wait t.waiters i ;
   if closed t then (
     notify_all t ;
     None
   ) else (
     if Mpmc_queue_1.is_empty t.queue then (
-      Waiters.commit_wait waiters waiter
+      Waiters.commit_wait t.waiters i
     ) else (
-      Waiters.cancel_wait waiters waiter
+      Waiters.cancel_wait t.waiters i
     ) ;
     match pop' t with
     | Some _ as res ->
         end_inactive t ;
         res
     | None ->
-        steal t
+        steal t i
   )
-let steal t _i ~max_round_noyield:_ ~max_round_yield:_ =
+let steal t i ~max_round_noyield:_ ~max_round_yield:_ =
   begin_inactive t ;
-  steal t
+  steal t i
 
 let close =
   begin_inactive

--- a/lib/zoo_parabs/ws_hub_fifo.ml
+++ b/lib/zoo_parabs/ws_hub_fifo.ml
@@ -42,51 +42,55 @@ let pop' t =
 let pop t _i =
   pop' t
 
-let rec steal_until t pred =
-  if pred () then (
-    None
-  ) else (
-    Domain.yield () ;
-    match pop' t with
-    | Some _ as res ->
-        res
-    | None ->
-        steal_until t pred
-  )
-let steal_until t _i ~max_round_noyield:_ pred =
-  steal_until t pred
-
-let rec steal t i =
+let rec steal_aux t i ~notification ~pred =
   Waiters.prepare_wait t.waiters i ;
-  if closed t then (
-    notify_all t ;
+  notification (fun () -> Waiters.notify t.waiters i) ;
+  if pred () then (
+    if not @@ Waiters.cancel_wait t.waiters i then
+      Waiters.notify_one t.waiters ;
     None
   ) else (
-    if Mpmc_queue_1.is_empty t.queue then (
-      Waiters.commit_wait t.waiters i
-    ) else (
-      Waiters.cancel_wait t.waiters i
-    ) ;
     match pop' t with
     | Some _ as res ->
-        end_inactive t ;
+        Waiters.cancel_wait t.waiters i |> ignore ;
         res
     | None ->
-        steal t i
+        Waiters.commit_wait t.waiters i ;
+        steal_aux t i ~notification:ignore ~pred
   )
+
+let steal_until t i ~max_round_noyield:_ ~max_round_yield:_ ~notification ~pred =
+  steal_aux t i ~notification ~pred
+
 let steal t i ~max_round_noyield:_ ~max_round_yield:_ =
   begin_inactive t ;
-  steal t i
+  let res =
+    steal_aux
+      t
+      i
+      ~notification:ignore
+      ~pred:(fun () -> closed t)
+  in
+  begin match res with
+  | None ->
+      notify_all t
+  | Some _ ->
+      end_inactive t
+  end ;
+  res
 
 let close =
   begin_inactive
 
-let pop_steal_until t i ~max_round_noyield pred =
-  match pop t i with
-  | Some _ as res ->
-      res
-  | None ->
-      steal_until t i ~max_round_noyield pred
+let pop_steal_until t i ~max_round_noyield ~max_round_yield ~notification ~pred =
+  if pred () then
+    None
+  else
+    match pop t i with
+    | Some _ as res ->
+        res
+    | None ->
+        steal_until t i ~max_round_noyield ~max_round_yield ~notification ~pred
 
 let pop_steal t i ~max_round_noyield ~max_round_yield =
   match pop t i with

--- a/lib/zoo_parabs/ws_hub_std.ml
+++ b/lib/zoo_parabs/ws_hub_std.ml
@@ -56,7 +56,7 @@ let try_steal_once t i =
   Random_round.reset round ;
   Ws_deques_public.steal_as t.queues i round
 
-let rec try_steal t i ~yield ~max_round pred =
+let rec try_steal t i ~yield ~max_round ~pred =
   if max_round <= 0 then
     Optional.Nothing
   else
@@ -69,78 +69,85 @@ let rec try_steal t i ~yield ~max_round pred =
         else (
           if yield then
             Domain.yield () ;
-          try_steal t i ~yield ~max_round:(max_round - 1) pred
+          try_steal t i ~yield ~max_round:(max_round - 1) ~pred
         )
-
-let rec steal_until t i pred =
-  match try_steal_once t i with
-  | Some _ as res ->
-      res
-  | None ->
-      if pred () then (
-        None
-      ) else (
-        Domain.yield () ;
-        steal_until t i pred
-      )
-let steal_until t i ~max_round_noyield pred =
-  match try_steal t i ~yield:false ~max_round:max_round_noyield pred with
-  | Optional.Something v ->
-      Some v
-  | Anything ->
-      None
-  | Nothing ->
-      steal_until t i pred
-let steal_until t i ~max_round_noyield pred =
-  block_active t i ;
-  let res = steal_until t i ~max_round_noyield pred in
-  unblock_active t i ;
-  res
-
-let steal_aux t i ~max_round_noyield ~max_round_yield pred =
-  match try_steal t i ~yield:false ~max_round:max_round_noyield pred with
+let try_steal t i ~max_round_noyield ~max_round_yield ~pred =
+  match try_steal t i ~yield:false ~max_round:max_round_noyield ~pred with
   | Optional.Something _ as res ->
       res
   | Anything ->
       Anything
   | Nothing ->
-      try_steal t i ~yield:true ~max_round:max_round_yield pred
-let rec steal t i ~max_round_noyield ~max_round_yield =
-  match steal_aux t i ~max_round_noyield ~max_round_yield (fun () -> closed t) with
+      try_steal t i ~yield:true ~max_round:max_round_yield ~pred
+
+let rec steal_aux t i ~max_round_noyield ~max_round_yield ~notification ~pred =
+  match try_steal t i ~max_round_noyield ~max_round_yield ~pred with
   | Optional.Something v ->
-      unblock t i ;
       Some v
   | Anything ->
-      notify_all t ;
       None
   | Nothing ->
       Waiters.prepare_wait t.waiters i ;
       match try_steal_once t i with
       | Some _ as res ->
-          Waiters.cancel_wait t.waiters i ;
-          unblock t i ;
+          Waiters.cancel_wait t.waiters i |> ignore ;
           res
       | None ->
-          if closed t then (
-            notify_all t ;
+          notification (fun () -> Waiters.notify t.waiters i) ;
+          if pred () then (
+            if not @@ Waiters.cancel_wait t.waiters i then
+              Waiters.notify_one t.waiters ;
             None
           ) else (
             Waiters.commit_wait t.waiters i ;
-            steal t i ~max_round_noyield ~max_round_yield
+            steal_aux t i ~max_round_noyield ~max_round_yield ~notification:ignore ~pred
           )
+
+let steal_until t i ~max_round_noyield ~max_round_yield ~notification ~pred =
+  block_active t i ;
+  let res =
+    steal_aux
+      t
+      i
+      ~max_round_noyield
+      ~max_round_yield
+      ~notification
+      ~pred
+  in
+  unblock_active t i ;
+  res
+
 let steal t i ~max_round_noyield ~max_round_yield =
   block t i ;
-  steal t i ~max_round_noyield ~max_round_yield
+  let res =
+    steal_aux
+      t
+      i
+      ~max_round_noyield
+      ~max_round_yield
+      ~notification:ignore
+      ~pred:(fun () -> closed t)
+  in
+  begin match res with
+  | None ->
+      notify_all t
+  | Some _ ->
+      unblock t i
+  end ;
+  res
 
 let close =
   begin_inactive
 
-let pop_steal_until t i ~max_round_noyield pred =
-  match pop t i with
-  | Some _ as res ->
-      res
-  | None ->
-      steal_until t i ~max_round_noyield pred
+let pop_steal_until t i ~max_round_noyield ~max_round_yield ~notification ~pred =
+  if pred () then
+    None
+  else
+    match pop t i with
+    | Some _ as res ->
+        res
+    | None ->
+        steal_until t i ~max_round_noyield ~max_round_yield ~notification ~pred
 
 let pop_steal t i ~max_round_noyield ~max_round_yield =
   match pop t i with

--- a/lib/zoo_parabs/ws_hub_std.ml
+++ b/lib/zoo_parabs/ws_hub_std.ml
@@ -12,7 +12,7 @@ type 'a t =
 let create sz =
   { queues= Ws_deques_public.create sz
   ; rounds= Array.unsafe_init sz (fun _ -> Random_round.create @@ Int.positive_part @@ sz - 1)
-  ; waiters= Waiters.create ()
+  ; waiters= Waiters.create sz
   ; num_active= sz + 1
   }
 
@@ -40,9 +40,9 @@ let closed t =
   t.num_active == 0
 
 let notify t =
-  Waiters.notify t.waiters
+  Waiters.notify_one t.waiters
 let notify_all t =
-  Waiters.notify_many t.waiters (size t)
+  Waiters.notify_all t.waiters
 
 let push t i v =
   Ws_deques_public.push t.queues i v ;
@@ -114,11 +114,10 @@ let rec steal t i ~max_round_noyield ~max_round_yield =
       notify_all t ;
       None
   | Nothing ->
-      let waiters = t.waiters in
-      let waiter = Waiters.prepare_wait waiters in
+      Waiters.prepare_wait t.waiters i ;
       match try_steal_once t i with
       | Some _ as res ->
-          Waiters.cancel_wait waiters waiter ;
+          Waiters.cancel_wait t.waiters i ;
           unblock t i ;
           res
       | None ->
@@ -126,7 +125,7 @@ let rec steal t i ~max_round_noyield ~max_round_yield =
             notify_all t ;
             None
           ) else (
-            Waiters.commit_wait waiters waiter ;
+            Waiters.commit_wait t.waiters i ;
             steal t i ~max_round_noyield ~max_round_yield
           )
 let steal t i ~max_round_noyield ~max_round_yield =

--- a/lib/zoo_std/ivar_3.ml
+++ b/lib/zoo_std/ivar_3.ml
@@ -50,3 +50,7 @@ let set t v =
       assert false
   | Unset waiters ->
       waiters
+
+let notify t ctx =
+  let waiters = set t () in
+  Lst.iter (fun waiter -> waiter ctx ()) waiters

--- a/lib/zoo_std/ivar_3.mli
+++ b/lib/zoo_std/ivar_3.mli
@@ -22,3 +22,6 @@ val wait :
 
 val set :
   ('a, 'waiter) t -> 'a -> 'waiter list
+
+val notify :
+  (unit, 'context -> unit -> unit) t -> 'context -> unit

--- a/theories/examples/vertex_fibonacci.v
+++ b/theories/examples/vertex_fibonacci.v
@@ -1,13 +1,14 @@
 From zoo Require Import
   prelude.
 From zoo.iris.base_logic Require Import
-  lib.fupd.
+  lib.fupd
+  lib.saved_prop.
 From zoo.language Require Import
   notations.
 From zoo.diaframe Require Import
   diaframe.
 From zoo_std Require Import
-  mpsc_flag.
+  ivar_3.
 From zoo_parabs Require Import
   pool
   vertex.
@@ -18,18 +19,20 @@ From zoo Require Import
   options.
 
 Implicit Types r : location.
-Implicit Types ctx vtx : val.
+Implicit Types v ctx vtx : val.
 
 Class VertexFibonacciG Σ `{zoo_G : !ZooG Σ} :=
   { #[local] vertex_fibonacci_G_pool_G :: PoolG Σ
   ; #[local] vertex_fibonacci_G_vertex_G :: VertexG Σ
-  ; #[local] vertex_fibonacci_G_mpsc_flag_G :: MpscFlagG Σ
+  ; #[local] vertex_fibonacci_G_ivar_G :: Ivar3G Σ gname
+  ; #[local] vertex_fibonacci_G_saved_prop_G :: SavedPropG Σ
   }.
 
 Definition vertex_fibonacci_Σ := #[
   pool_Σ ;
   vertex_Σ ;
-  mpsc_flag_Σ
+  ivar_3_Σ gname ;
+  saved_prop_Σ
 ].
 #[global] Instance subG_vertex_fibonacci_Σ Σ `{zoo_G : !ZooG Σ} :
   subG vertex_fibonacci_Σ Σ →
@@ -142,16 +145,21 @@ Section vertex_fibonacci_G.
       wp_apply+ (vertex_release𑁒spec with "[$Hctx $Hvtx1_inv $Hvtx1_model Hr]") as "Hctx".
       { iApply (vertex_fibonacci_main₀𑁒spec with "Hvtx1_inv Hr"). }
 
-      wp_apply+ (mpsc_flag_create𑁒spec
-        (r ↦ᵣ #(fibonacci n))
-      with "[//]") as (flag) "(#Hflag_inv & Hflag_consumer)".
+      wp_apply+ (ivar_3_create𑁒spec
+        (λ _, r ↦ᵣ #(fibonacci n))%I
+        (λ _, True)%I
+        ( λ _ waiter _,
+          ∀ ctx v,
+          WP waiter ctx v {{ itype_unit }}
+        )%I
+      with "[//]") as (ivar) "(#Hivar_inv & Hivar_producer & Hivar_consumer)".
 
       wp_apply+ (vertex_create'𑁒spec
         True
         True
       with "[//]") as (vtx2 iter2) "(#Hvtx2_inv & Hvtx2_model & _)".
       wp_apply+ (vertex_precede𑁒spec with "[$Hvtx2_model]") as "(Hvtx2_model & #Hvtx1_predecessor)". 1: iFrame "#".
-      wp_apply+ (vertex_release𑁒spec' with "[$Hctx $Hvtx2_model Hvtx1_output]") as "Hctx".
+      wp_apply+ (vertex_release𑁒spec' with "[$Hctx $Hvtx2_model Hvtx1_output Hivar_producer]") as "Hctx".
       { iFrame "#". iIntros "{%} %pool %ctx %scope Hctx #Hvtx2_ready".
 
         wp_pures credits:"H£".
@@ -160,19 +168,12 @@ Section vertex_fibonacci_G.
         iDestruct (vertex_predecessor_finished with "Hvtx1_predecessor Hvtx2_ready") as "#Hvtx1_finished".
         iMod (vertex_inv_finished_output' with "H£ Hvtx1_inv Hvtx1_finished Hvtx1_output") as "Hr".
 
-        wp_apply+ (mpsc_flag_set𑁒spec with "[$Hflag_inv $Hr]").
+        wp_apply+ (ivar_3_notify𑁒spec True with "[$Hivar_inv $Hivar_producer $Hr]"). 1: iSteps.
         iSteps.
       }
 
-      wp_apply+ (pool_wait_until𑁒spec
-        (mpsc_flag_consumer flag)
-        (r ↦ᵣ #(fibonacci n))
-      with "[$Hctx Hflag_consumer]").
-      { iStep 3 as "Hflag_consumer".
-        wp_apply+ (mpsc_flag_get𑁒spec with "[$Hflag_inv $Hflag_consumer]").
-        iSteps.
-      }
-
+      wp_apply+ (pool_wait_ivar𑁒spec with "[$Hctx $Hivar_inv]") as "(H£ & $ & (%v & #Hivar_result))". 1: iSteps.
+      iMod (ivar_3_inv_result_consumer' with "H£ Hivar_inv Hivar_result Hivar_consumer") as "(Hr & _)".
       iSteps.
     }
 

--- a/theories/examples/vertex_fibonacci__code.v
+++ b/theories/examples/vertex_fibonacci__code.v
@@ -7,7 +7,7 @@ From zoo_parabs Require Import
   pool
   vertex.
 From zoo_std Require Import
-  mpsc_flag.
+  ivar_3.
 From examples Require Import
   vertex_fibonacci__types.
 From zoo Require Import
@@ -46,11 +46,11 @@ Definition vertex_fibonacci_main : val :=
            "vtx1"
            (fun: "ctx" => vertex_fibonacci_main₀ "ctx" "vtx1" "r" "n") ;;
          vertex_release "ctx" "vtx1" ;;
-         let: "flag" := mpsc_flag_create () in
+         let: "ivar" := ivar_3_create () in
          let: "vtx2" :=
-           vertex_create' (fun: "_ctx" => mpsc_flag_set "flag")
+           vertex_create' (fun: "ctx" => ivar_3_notify "ivar" "ctx")
          in
          vertex_precede "vtx1" "vtx2" ;;
          vertex_release "ctx" "vtx2" ;;
-         pool_wait_until "ctx" (fun: <> => mpsc_flag_get "flag") ;;
+         pool_wait_ivar "ctx" "ivar" ;;
          !"r").

--- a/theories/examples/vertex_fibonacci__types.v
+++ b/theories/examples/vertex_fibonacci__types.v
@@ -7,7 +7,7 @@ From zoo_parabs Require Import
   pool
   vertex.
 From zoo_std Require Import
-  mpsc_flag.
+  ivar_3.
 From zoo Require Import
   options.
 

--- a/theories/examples/vertex_simple.v
+++ b/theories/examples/vertex_simple.v
@@ -1,13 +1,14 @@
 From zoo Require Import
   prelude.
 From zoo.iris.base_logic Require Import
-  lib.fupd.
+  lib.fupd
+  lib.saved_prop.
 From zoo.language Require Import
   notations.
 From zoo.diaframe Require Import
   diaframe.
 From zoo_std Require Import
-  mpsc_flag.
+  ivar_3.
 From zoo_parabs Require Import
   pool
   vertex.
@@ -16,18 +17,20 @@ From examples Require Export
 From zoo Require Import
   options.
 
-Implicit Types a b c d : val.
+Implicit Types v ctx a b c d : val.
 
 Class VertexSimpleG Σ `{zoo_G : !ZooG Σ} :=
   { #[local] vertex_simple_G_pool_G :: PoolG Σ
   ; #[local] vertex_simple_G_vertex_G :: VertexG Σ
-  ; #[local] vertex_simple_G_mpsc_flag_G :: MpscFlagG Σ
+  ; #[local] vertex_simple_G_ivar_G :: Ivar3G Σ gname
+  ; #[local] vertex_simple_G_saved_prop_G :: SavedPropG Σ
   }.
 
 Definition vertex_simple_Σ := #[
   pool_Σ ;
   vertex_Σ ;
-  mpsc_flag_Σ
+  ivar_3_Σ gname ;
+  saved_prop_Σ
 ].
 #[global] Instance subG_vertex_simple_Σ Σ `{zoo_G : !ZooG Σ} :
   subG vertex_simple_Σ Σ →
@@ -57,7 +60,15 @@ Section vertex_simple_G.
     iIntros "%Φ (Ha & Hb & Hc & Hd) HΦ".
 
     wp_rec.
-    wp_apply+ (mpsc_flag_create𑁒spec P_d with "[//]") as (flag) "(#Hflag_inv & Hflag_consumer)".
+
+    wp_apply+ (ivar_3_create𑁒spec
+      (λ _, P_d)
+      (λ _, True)%I
+      ( λ _ waiter _,
+        ∀ ctx v,
+        WP waiter ctx v {{ itype_unit }}
+      )%I
+    with "[//]") as (ivar) "(#Hivar_inv & Hivar_producer & Hivar_consumer)".
 
     wp_apply+ (vertex_create'𑁒spec
       (P_ab ∗ P_ac)
@@ -88,7 +99,7 @@ Section vertex_simple_G.
     )%I with "[- HΦ]") as (pool ?) "(_ & -> & HP_d)". 1: lia.
     { iIntros "%pool %ctx %scope _ Hctx".
 
-      wp_apply+ (vertex_release𑁒spec' with "[$Hctx $Hvtx_d_model Hvtx_b_output Hvtx_c_output Hd]") as "Hctx".
+      wp_apply+ (vertex_release𑁒spec' with "[$Hctx $Hvtx_d_model Hvtx_b_output Hvtx_c_output Hd Hivar_producer]") as "Hctx".
       { iFrame "#". iIntros "{%} %pool %ctx %scope Hctx #Hvtx_d_ready".
 
         wp_pures credits:"H£".
@@ -103,8 +114,8 @@ Section vertex_simple_G.
         iMod (lc_fupd_elim_laterN _ (P_b ∗ P_c) with "H£ [$]") as "(HP_b & HP_c)".
         wp_apply (wp_wand with "(Hd HP_b HP_c)") as (res) "(-> & HP_d)".
 
-        wp_apply+ (mpsc_flag_set𑁒spec with "[$Hflag_inv $HP_d]").
-        iSteps => //.
+        wp_apply+ (ivar_3_notify𑁒spec True with "[$Hivar_inv $Hivar_producer $HP_d]"). 1: iSteps.
+        iSteps.
       }
 
       wp_apply+ (vertex_release𑁒spec' with "[$Hctx $Hvtx_c_model Hvtx_a_output_c Hc]") as "Hctx".
@@ -140,16 +151,9 @@ Section vertex_simple_G.
         iSteps => //.
       }
 
-      wp_apply+ (pool_wait_until𑁒spec
-        (mpsc_flag_consumer flag)
-        P_d
-      with "[$Hctx Hflag_consumer]").
-      { iStep 3 as "Hflag_consumer".
-        wp_apply+ (mpsc_flag_get𑁒spec with "[$Hflag_inv $Hflag_consumer]").
-        iSteps.
-      }
-
-      iSteps.
+      iApply wp_fupd.
+      wp_apply+ (pool_wait_ivar𑁒spec with "[$Hctx $Hivar_inv]") as "(H£ & $ & (%v & #Hivar_result))". 1: iSteps.
+      iMod (ivar_3_inv_result_consumer' with "H£ Hivar_inv Hivar_result Hivar_consumer") as "($ & _)" => //.
     }
 
     iSteps.

--- a/theories/examples/vertex_simple__code.v
+++ b/theories/examples/vertex_simple__code.v
@@ -7,7 +7,7 @@ From zoo_parabs Require Import
   pool
   vertex.
 From zoo_std Require Import
-  mpsc_flag.
+  ivar_3.
 From examples Require Import
   vertex_simple__types.
 From zoo Require Import
@@ -15,13 +15,13 @@ From zoo Require Import
 
 Definition vertex_simple_main : val :=
   fun: "num_worker" "a" "b" "c" "d" =>
-    let: "flag" := mpsc_flag_create () in
+    let: "ivar" := ivar_3_create () in
     let: "vtx_a" := vertex_create' (fun: "_ctx" => "a" ()) in
     let: "vtx_b" := vertex_create' (fun: "_ctx" => "b" ()) in
     let: "vtx_c" := vertex_create' (fun: "_ctx" => "c" ()) in
     let: "vtx_d" :=
-      vertex_create' (fun: "_ctx" => "d" () ;;
-                                     mpsc_flag_set "flag")
+      vertex_create' (fun: "ctx" => "d" () ;;
+                                    ivar_3_notify "ivar" "ctx")
     in
     vertex_precede "vtx_a" "vtx_b" ;;
     vertex_precede "vtx_a" "vtx_c" ;;
@@ -34,4 +34,4 @@ Definition vertex_simple_main : val :=
          vertex_release "ctx" "vtx_c" ;;
          vertex_release "ctx" "vtx_b" ;;
          vertex_release "ctx" "vtx_a" ;;
-         pool_wait_until "ctx" (fun: <> => mpsc_flag_get "flag")).
+         pool_wait_ivar "ctx" "ivar").

--- a/theories/examples/vertex_simple__types.v
+++ b/theories/examples/vertex_simple__types.v
@@ -7,7 +7,7 @@ From zoo_parabs Require Import
   pool
   vertex.
 From zoo_std Require Import
-  mpsc_flag.
+  ivar_3.
 From zoo Require Import
   options.
 

--- a/theories/zoo_parabs/future.v
+++ b/theories/zoo_parabs/future.v
@@ -412,15 +412,7 @@ Section future_G.
 
     wp_rec.
 
-    wp_apply+ (pool_wait_until𑁒spec
-      True
-      (ivar_3_resolved t)
-    with "[$Hctx]") as "(Hctx & %v & #Hresult)".
-    { iStep 3.
-      wp_apply+ (ivar_3_is_set𑁒spec with "Hinv") as (b) "Hresult".
-      rewrite /ivar_3_resolved. destruct b; iSteps.
-    }
-
+    wp_apply+ (pool_wait_ivar𑁒spec with "[$Hctx $Hinv]") as "(_ & Hctx & %v & #Hresult)". 1: iSteps.
     wp_apply+ (ivar_3_get𑁒spec with "[$Hinv $Hresult]") as "H£".
     iSteps.
   Qed.

--- a/theories/zoo_parabs/future__code.v
+++ b/theories/zoo_parabs/future__code.v
@@ -29,7 +29,7 @@ Definition future_async : val :=
 
 Definition future_wait : val :=
   fun: "ctx" "t" =>
-    pool_wait_until "ctx" (fun: <> => ivar_3_is_set "t") ;;
+    pool_wait_ivar "ctx" "t" ;;
     ivar_3_get "t".
 
 Definition future_iter : val :=

--- a/theories/zoo_parabs/pool.v
+++ b/theories/zoo_parabs/pool.v
@@ -16,7 +16,8 @@ From zoo.diaframe Require Import
   diaframe.
 From zoo_std Require Import
   array
-  domain.
+  domain
+  ivar_3.
 From zoo_parabs Require Export
   base
   pool__code.
@@ -27,10 +28,11 @@ From zoo Require Import
   options.
 
 Implicit Types b : bool.
-Implicit Types v ctx hub task pred : val.
+Implicit Types v ctx hub task notification notify pred ivar waiter : val.
 Implicit Types empty : emptiness.
 Implicit Types own : ownership.
 Implicit Types η : spsc_prop_name.
+Implicit Types ω : gname.
 
 #[local] Definition max_round_noyield :=
   val_to_nat' pool_max_round_noyield.
@@ -114,7 +116,7 @@ Module base.
     Context `{pool_G : PoolG Σ}.
 
     Implicit Types t : location.
-    Implicit Types P Q : iProp Σ.
+    Implicit Types P P_notification P_pred Q Q_pred : iProp Σ.
     Implicit Types Ψ : val → iProp Σ.
 
     Record pool_name :=
@@ -1071,37 +1073,47 @@ Module base.
       }
     Qed.
 
-    Lemma pool_wait_until𑁒spec P Q γ ctx scope pred :
+    #[local] Lemma pool_wait₀𑁒spec P_notification P_pred Q_pred γ ctx scope notification pred :
       {{{
         pool_context γ ctx scope ∗
-        P ∗
+        P_notification ∗
         □ (
-          P -∗
+          ∀ notify,
+          P_notification -∗
+          WP notify () {{ itype_unit }} -∗
+          WP notification notify {{ res,
+            ⌜res = ()%V⌝ ∗
+            P_notification
+          }}
+        ) ∗
+        P_pred ∗
+        □ (
+          P_pred -∗
           WP pred () {{ res,
             ∃ b,
             ⌜res = #b⌝ ∗
-            if b then Q else P
+            if b then Q_pred else P_pred
           }}
         )
       }}}
-        pool_wait_until ctx pred
+        pool_wait₀ ctx notification pred
       {{{
         RET ();
         pool_context γ ctx scope ∗
-        Q
+        Q_pred
       }}}.
     Proof.
-      iIntros "%Φ ((:context lazy=) & HP & #Hpred) HΦ".
+      iIntros "%Φ ((:context lazy=) & HP_notification & #Hnotification & HP_pred & #Hpred) HΦ".
+
       iLöb as "HLöb".
+
       iDestruct "Hctx" as "(:context_1)".
 
-      wp_rec. rewrite pool_max_round_noyield.
-      wp_apply+ (wp_wand with "(Hpred HP)") as (res) "(%b & -> & H)".
-      destruct b; first iSteps.
+      wp_rec. rewrite pool_max_round_noyield pool_max_round_yield.
 
-      awp_apply+ (ws_hub_std_pop_steal_until𑁒spec P Q with "[$Hhub_inv $Hhub_owner $H $Hpred]") without "HΦ"; [done.. |].
+      awp_apply+ (ws_hub_std_pop_steal_until𑁒spec P_notification P_pred Q_pred with "[$Hhub_inv $Hhub_owner $HP_notification $Hnotification $HP_pred $Hpred]") without "HΦ". 1-3: done.
       iInv "Hinv" as "(:inv_inner)".
-      iAaccIntro with "Hhub_model"; first iSteps. iIntros ([𝑔𝑙𝑜𝑏𝑎𝑙 |]) "Hhub_model".
+      iAaccIntro with "Hhub_model". 1: iSteps. iIntros ([𝑔𝑙𝑜𝑏𝑎𝑙 |]) "Hhub_model".
 
       - iDestruct "Hhub_model" as "(%𝑔𝑙𝑜𝑏𝑎𝑙𝑠' & -> & Hhub_model)".
         apply symmetry, gmultiset_map_disj_union_singleton_l_inv in H𝑔𝑙𝑜𝑏𝑎𝑙𝑠 as (global & globals' & -> & -> & ->).
@@ -1109,42 +1121,119 @@ Module base.
         iEval (rewrite big_sepMS_singleton) in "Hglobal".
         iMod (globals_model_pop global with "Hglobals_model Hlocals_at") as "(Hglobals_model & Hlocals_at)"; [done.. |].
         iSplitR "Hglobal Hlocals_at". { iFrameSteps. }
-        iIntros "!> {%- Hi} %empty (Hhub_owner & HP) HΦ".
+        iIntros "!> {%- Hi} %empty (Hhub_owner & HP_notification & HP_pred) HΦ".
 
         wp_apply+ (pool_execute𑁒spec with "[$]") as "{%- Hi} %res ((:context_1) & (%R & Hglobal & HR))"; first done.
         iDestruct (locals_at_finish with "Hlocals_at Hglobal HR") as "Hlocals_at".
-        wp_apply+ ("HLöb" with "[$] HP HΦ").
+        wp_apply+ ("HLöb" with "[$] HP_notification HP_pred HΦ").
 
       - iSplitR "Hlocals_at". { iFrameSteps. }
         iSteps.
     Qed.
 
-    Lemma pool_wait_while𑁒spec P Q γ ctx scope pred :
+    Lemma pool_wait𑁒spec P_notification P_pred Q_pred γ ctx scope notification pred :
       {{{
         pool_context γ ctx scope ∗
-        P ∗
+        P_notification ∗
+        ( ∀ notify,
+          P_notification -∗
+          WP notify () {{ itype_unit }} -∗
+          WP notification notify {{ res,
+            ⌜res = ()%V⌝ ∗
+            P_notification
+          }}
+        ) ∗
+        P_pred ∗
         □ (
-          P -∗
+          P_pred -∗
           WP pred () {{ res,
             ∃ b,
             ⌜res = #b⌝ ∗
-            if b then P else Q
+            if b then Q_pred else P_pred
           }}
         )
       }}}
-        pool_wait_while ctx pred
+        pool_wait ctx notification pred
       {{{
         RET ();
         pool_context γ ctx scope ∗
-        Q
+        Q_pred
       }}}.
     Proof.
-      iIntros "%Φ (Hctx & HP & #Hpred) HΦ".
+      iIntros "%Φ (Hctx & HP_notification & Hnotification & HP_pred & #Hpred) HΦ".
+
+      lazymatch iTypeOf "Hnotification" with
+      | Some (_, ?P) =>
+          pose Q_notification := P
+      end.
 
       wp_rec.
-      wp_apply+ (pool_wait_until𑁒spec P Q with "[$Hctx $HP] HΦ") as "!> HP".
-      wp_apply+ (wp_wand with "(Hpred HP)") as (res) "(%b & -> & H)".
-      destruct b; iSteps.
+      wp_ref notification_registered as "Hnotification_registered".
+
+      wp_apply+ (pool_wait₀𑁒spec
+        ( ∃ b,
+          notification_registered ↦ᵣ #b ∗
+          P_notification ∗
+          if b then True else Q_notification
+        )
+        P_pred
+        Q_pred
+      with "[$Hctx $Hnotification_registered $HP_notification $Hnotification $HP_pred $Hpred]").
+      { iIntros "!> %notify (%b & Hnotification & HP_notification & HQ_notification) Hnotify".
+        wp_load.
+        destruct b; iSteps.
+      }
+
+      iSteps.
+    Qed.
+
+    Lemma pool_wait_ivar𑁒spec `{ivar_G : !Ivar3G Σ gname} `{saved_prop_G : !SavedPropG Σ} γ ctx scope ivar Ψ Ξ Ω :
+      {{{
+        pool_context γ ctx scope ∗
+        ivar_3_inv ivar Ψ Ξ Ω ∗
+        ( ∀ waiter ω,
+          ( ∀ ctx v,
+            WP waiter ctx v {{ res,
+              ∃ P,
+              ⌜res = ()%V⌝ ∗
+              saved_prop ω P ∗
+              ▷ □ P
+            }}
+          ) -∗
+          Ω ivar waiter ω
+        )
+      }}}
+        pool_wait_ivar ctx ivar
+      {{{
+        RET ();
+        £ 2 ∗
+        pool_context γ ctx scope ∗
+        ivar_3_resolved ivar
+      }}}.
+    Proof.
+      iIntros "%Φ (Hctx & #Hivar_inv & HΩ) HΦ".
+
+      wp_rec credits:"H£".
+      iApply (lc_weaken 2) in "H£"; first done.
+
+      wp_apply+ (pool_wait𑁒spec
+        True
+        True
+        (ivar_3_resolved ivar)
+      with "[$Hctx HΩ]").
+      { repeat iSplit. 1,3: done.
+
+        - iIntros "%notify _ Hnotify".
+          iMod (saved_prop_alloc True) as "(%ω & #Hω)".
+          wp_apply+ (ivar_3_wait𑁒spec with "[$Hivar_inv HΩ Hnotify]") as ([waiter |]) "".
+          all: iSteps.
+
+        - iIntros "!> _".
+          wp_apply+ (ivar_3_is_set𑁒spec with "Hivar_inv") as "%b".
+          destruct b; iSteps.
+      }
+
+      iSteps.
     Qed.
   End pool_G.
 
@@ -1166,7 +1255,7 @@ Section pool_G.
   Implicit Types 𝑡 : location.
   Implicit Types t : val.
   Implicit Types γ : base.pool_name.
-  Implicit Types P Q : iProp Σ.
+  Implicit Types P P_notification P_pred Q Q_pred : iProp Σ.
   Implicit Types Ψ : val → iProp Σ.
 
   Definition pool_inv t sz : iProp Σ :=
@@ -1534,55 +1623,68 @@ Section pool_G.
     iApply ("Hconsumer" with "Hfinished_1").
   Qed.
 
-  Lemma pool_wait_until𑁒spec P Q t ctx scope pred :
+  Lemma pool_wait𑁒spec P_notification P_pred Q_pred t ctx scope notification pred :
     {{{
       pool_context t ctx scope ∗
-      P ∗
+      P_notification ∗
+      ( ∀ notify,
+        P_notification -∗
+        WP notify () {{ itype_unit }} -∗
+        WP notification notify {{ res,
+          ⌜res = ()%V⌝ ∗
+          P_notification
+        }}
+      ) ∗
+      P_pred ∗
       □ (
-        P -∗
+        P_pred -∗
         WP pred () {{ res,
           ∃ b,
           ⌜res = #b⌝ ∗
-          if b then Q else P
+          if b then Q_pred else P_pred
         }}
       )
     }}}
-      pool_wait_until ctx pred
+      pool_wait ctx notification pred
     {{{
       RET ();
       pool_context t ctx scope ∗
-      Q
+      Q_pred
     }}}.
   Proof.
     iIntros "%Φ ((:context) & HP & Hpred) HΦ".
 
-    wp_apply (base.pool_wait_until𑁒spec with "[$]").
+    wp_apply (base.pool_wait𑁒spec with "[$]").
     iSteps.
   Qed.
 
-  Lemma pool_wait_while𑁒spec P Q t ctx scope pred :
+  Lemma pool_wait_ivar𑁒spec `{ivar_G : !Ivar3G Σ gname} `{saved_prop_G : !SavedPropG Σ} t ctx scope ivar Ψ Ξ Ω :
     {{{
       pool_context t ctx scope ∗
-      P ∗
-      □ (
-        P -∗
-        WP pred () {{ res,
-          ∃ b,
-          ⌜res = #b⌝ ∗
-          if b then P else Q
-        }}
+      ivar_3_inv ivar Ψ Ξ Ω ∗
+      ( ∀ waiter ω,
+        ( ∀ ctx v,
+          WP waiter ctx v {{ res,
+            ∃ P,
+            ⌜res = ()%V⌝ ∗
+            saved_prop ω P ∗
+            ▷ □ P
+          }}
+        ) -∗
+        Ω ivar waiter ω
       )
     }}}
-      pool_wait_while ctx pred
+      pool_wait_ivar ctx ivar
     {{{
       RET ();
+      £ 2 ∗
       pool_context t ctx scope ∗
-      Q
+      ivar_3_resolved ivar
     }}}.
   Proof.
-    iIntros "%Φ ((:context) & HP & Hpred) HΦ".
+    iIntros "%Φ ((:context) & Hivar_inv & HΩ) HΦ".
 
-    wp_apply (base.pool_wait_while𑁒spec with "[$]").
+    wp_apply (base.pool_wait_ivar𑁒spec with "[$]").
     iSteps.
   Qed.
 End pool_G.

--- a/theories/zoo_parabs/pool__code.v
+++ b/theories/zoo_parabs/pool__code.v
@@ -6,6 +6,7 @@ From zoo.language Require Import
 From zoo_parabs Require Import
   ws_hub_std.
 From zoo_std Require Import
+  ivar_3
   array
   domain.
 From zoo_parabs Require Import
@@ -89,24 +90,40 @@ Definition pool_async : val :=
   fun: "ctx" "task" =>
     ws_hub_std_push "ctx".<context_hub> "ctx".<context_id> "task".
 
-Definition pool_wait_until : val :=
-  rec: "wait_until" "ctx" "pred" =>
-    if: ~ "pred" () then (
-      match:
-        ws_hub_std_pop_steal_until
-          "ctx".<context_hub>
-          "ctx".<context_id>
-          pool_max_round_noyield
-          "pred"
-      with
-      | None =>
-          ()
-      | Some "job" =>
-          pool_execute "ctx" "job" ;;
-          "wait_until" "ctx" "pred"
-      end
-    ).
+Definition pool_wait₀ : val :=
+  rec: "wait" "ctx" "notification" "pred" =>
+    match:
+      ws_hub_std_pop_steal_until
+        "ctx".<context_hub>
+        "ctx".<context_id>
+        pool_max_round_noyield
+        pool_max_round_yield
+        "notification"
+        "pred"
+    with
+    | None =>
+        ()
+    | Some "job" =>
+        pool_execute "ctx" "job" ;;
+        "wait" "ctx" "notification" "pred"
+    end.
 
-Definition pool_wait_while : val :=
-  fun: "ctx" "pred" =>
-    pool_wait_until "ctx" (fun: <> => ~ "pred" ()).
+Definition pool_wait : val :=
+  fun: "ctx" "notification" "pred" =>
+    let: "notification_registered" := ref false in
+    let: "notification" "notify" :=
+      if: ~ !"notification_registered" then (
+        "notification_registered" <- true ;;
+        "notification" "notify"
+      )
+    in
+    pool_wait₀ "ctx" "notification" "pred".
+
+Definition pool_wait_ivar : val :=
+  fun: "ctx" "ivar" =>
+    pool_wait
+      "ctx"
+      (fun: "notify" =>
+         ivar_3_wait "ivar" (fun: "_ctx" "_v" => "notify" ()) ;;
+         ())
+      (fun: <> => ivar_3_is_set "ivar").

--- a/theories/zoo_parabs/pool__opaque.v
+++ b/theories/zoo_parabs/pool__opaque.v
@@ -7,5 +7,5 @@ From zoo_parabs Require Import
 #[global] Opaque pool_run.
 #[global] Opaque pool_size.
 #[global] Opaque pool_async.
-#[global] Opaque pool_wait_until.
-#[global] Opaque pool_wait_while.
+#[global] Opaque pool_wait.
+#[global] Opaque pool_wait_ivar.

--- a/theories/zoo_parabs/pool__types.v
+++ b/theories/zoo_parabs/pool__types.v
@@ -6,6 +6,7 @@ From zoo.language Require Import
 From zoo_parabs Require Import
   ws_hub_std.
 From zoo_std Require Import
+  ivar_3
   array
   domain.
 From zoo Require Import

--- a/theories/zoo_parabs/waiter.v
+++ b/theories/zoo_parabs/waiter.v
@@ -145,15 +145,19 @@ Section waiter_G.
     }}}
       waiter_cancel_wait t
     {{{
-      RET ();
+      b
+    , RET #b;
       True
     }}}.
   Proof.
     iIntros "%Φ (:inv) HΦ".
 
     wp_rec. wp_load.
-    wp_apply (mutex_protect𑁒spec itype_unit with "[$Hmtx_inv]"). 1: iSteps.
-    iSteps.
+    wp_apply (mutex_protect𑁒spec itype_bool with "[$Hmtx_inv]"). 2: iSteps.
+    { iIntros "Hmtx_locked (:inv_inner)".
+      wp_load.
+      destruct b; iSteps.
+    }
   Qed.
 
   Lemma waiter_commit_wait𑁒spec t :

--- a/theories/zoo_parabs/waiter.v
+++ b/theories/zoo_parabs/waiter.v
@@ -39,7 +39,7 @@ Qed.
 Section waiter_G.
   Context `{waiter_G : WaiterG Σ}.
 
-  #[local] Definition waiter_inv_inner 𝑡 : iProp Σ :=
+  #[local] Definition inv_inner 𝑡 : iProp Σ :=
     ∃ b,
     𝑡.[flag] ↦ #b.
   #[local] Instance : CustomIpat "inv_inner" :=
@@ -51,20 +51,18 @@ Section waiter_G.
     ∃ 𝑡 mtx cond,
     ⌜t = #𝑡⌝ ∗
     𝑡.[mutex] ↦□ mtx ∗
-    mutex_inv mtx True ∗
+    mutex_inv mtx (inv_inner 𝑡) ∗
     𝑡.[condition] ↦□ cond ∗
-    condition_inv cond ∗
-    inv nroot (waiter_inv_inner 𝑡).
+    condition_inv cond.
   #[local] Instance : CustomIpat "inv" :=
     " ( %𝑡
       & %mtx
       & %cond
       & ->
       & #H𝑡_mutex
-      & #Hmutex_inv
+      & #Hmtx_inv
       & #H𝑡_condition
-      & #Hcondition_inv
-      & #Hinv
+      & #Hcond_inv
       )
     ".
 
@@ -88,9 +86,11 @@ Section waiter_G.
     iIntros "%Φ _ HΦ".
 
     wp_rec.
-    wp_apply+ (condition_create𑁒spec with "[//]") as "%cond #Hcondition_inv".
-    wp_apply+ (mutex_create𑁒spec True with "[//]") as "%mtx #Hmutex_inv".
+    wp_apply (condition_create𑁒spec with "[//]") as "%cond #Hcond_inv".
+    wp_apply (mutex_create𑁒spec_init with "[//]") as "%mtx Hmtx_init".
+    wp_block 𝑡 as "(H𝑡_mutex & H𝑡_condition & H𝑡_flag & _)".
 
+    iMod (mutex_init_to_inv (inv_inner 𝑡) with "Hmtx_init [$H𝑡_flag]").
     iSteps.
   Qed.
 
@@ -107,41 +107,18 @@ Section waiter_G.
   Proof.
     iIntros "%Φ (:inv) HΦ".
 
-    wp_rec.
-
-    wp_bind (_.{flag})%E.
-    iInv "Hinv" as "(:inv_inner)".
+    wp_rec. wp_load.
+    wp_apply (mutex_lock𑁒spec with "Hmtx_inv") as "(Hmtx_locked & (:inv_inner))".
     wp_load.
-    destruct b. 1: iSteps.
-    iSplitR "HΦ". { iFrameSteps. }
-    iModIntro.
-
-    wp_load.
-    wp_apply (mutex_lock𑁒spec with "Hmutex_inv") as "(Hmutex_locked & _)".
-    wp_pures.
-
-    wp_bind (_.{flag})%E.
-    iInv "Hinv" as "(:inv_inner)".
-    wp_load.
-    iSplitR "Hmutex_locked HΦ". { iFrameSteps. }
-    iModIntro.
-
     destruct b; wp_pures.
 
     - wp_load.
-      wp_apply (mutex_unlock𑁒spec with "[$Hmutex_inv $Hmutex_locked //]") as "_".
+      wp_apply (mutex_unlock𑁒spec with "[$Hmtx_inv $Hmtx_locked $H𝑡_flag]").
       iSteps.
 
     - wp_bind (_ <-{flag} _)%E.
-      iInv "Hinv" as "(:inv_inner)".
-      wp_store.
-      iSplitR "Hmutex_locked HΦ". { iFrameSteps. }
-      iModIntro.
-
-      wp_load.
-      wp_apply (mutex_unlock𑁒spec with "[$Hmutex_inv $Hmutex_locked //]") as "_".
-      wp_load.
-      wp_apply (condition_notify𑁒spec with "Hcondition_inv").
+      wp_store. wp_load.
+      wp_apply (mutex_unlock𑁒spec with "[$Hmtx_inv $Hmtx_locked $H𝑡_flag]").
       iSteps.
   Qed.
 
@@ -155,6 +132,10 @@ Section waiter_G.
       True
     }}}.
   Proof.
+    iIntros "%Φ (:inv) HΦ".
+
+    wp_rec. wp_load.
+    wp_apply (mutex_protect𑁒spec itype_unit with "[$Hmtx_inv]"). 1: iSteps.
     iSteps.
   Qed.
 
@@ -168,6 +149,10 @@ Section waiter_G.
       True
     }}}.
   Proof.
+    iIntros "%Φ (:inv) HΦ".
+
+    wp_rec. wp_load.
+    wp_apply (mutex_protect𑁒spec itype_unit with "[$Hmtx_inv]"). 1: iSteps.
     iSteps.
   Qed.
 
@@ -183,24 +168,11 @@ Section waiter_G.
   Proof.
     iIntros "%Φ (:inv) HΦ".
 
-    wp_rec.
-
-    wp_bind (_.{flag})%E.
-    iInv "Hinv" as "(:inv_inner)".
-    wp_load.
-    destruct b. 1: iSteps.
-    iSplitR "HΦ". { iFrameSteps. }
-    iModIntro.
-
-    wp_load.
-    wp_apply+ (mutex_protect𑁒spec (λ res,
-      ⌜res = ()%V⌝
-    )%I with "[$Hmutex_inv]").
-    { iIntros "Hmutex_locked _".
-      do 2 wp_load.
-      wp_apply (condition_wait_until𑁒spec (λ _, True)%I with "[$Hcondition_inv $Hmutex_inv $Hmutex_locked]").
-      all: iSteps.
-    }
+    wp_rec. wp_load.
+    wp_apply (mutex_protect𑁒spec itype_unit with "[$Hmtx_inv]"). 2: iSteps.
+    iIntros "Hmtx_locked (:inv_inner)".
+    do 2 wp_load.
+    wp_apply (condition_wait_until𑁒spec (λ _, True)%I with "[$Hcond_inv $Hmtx_inv $Hmtx_locked $H𝑡_flag]"). 1: iSteps.
     iSteps.
   Qed.
 End waiter_G.

--- a/theories/zoo_parabs/waiter.v
+++ b/theories/zoo_parabs/waiter.v
@@ -1,0 +1,211 @@
+From zoo Require Import
+  prelude.
+From zoo.language Require Import
+  notations.
+From zoo.diaframe Require Import
+  diaframe.
+From zoo_std Require Import
+  condition
+  mutex.
+From zoo_saturn Require Import
+  mpmc_queue_1.
+From zoo_parabs Require Export
+  base
+  waiter__code.
+From zoo_parabs Require Import
+  base
+  waiter__types.
+From zoo Require Import
+  options.
+
+Implicit Types b : bool.
+Implicit Types 𝑡 : location.
+Implicit Types v t mtx cond : val.
+
+Class WaiterG Σ `{zoo_G : !ZooG Σ} :=
+  { #[local] waiter_G_mutex_G :: MutexG Σ
+  }.
+
+Definition waiter_Σ := #[
+  mutex_Σ
+].
+#[global] Instance subG_ws_hub_Σ Σ `{zoo_G : !ZooG Σ} :
+  subG waiter_Σ Σ →
+  WaiterG Σ.
+Proof.
+  solve_inG.
+Qed.
+
+Section waiter_G.
+  Context `{waiter_G : WaiterG Σ}.
+
+  #[local] Definition waiter_inv_inner 𝑡 : iProp Σ :=
+    ∃ b,
+    𝑡.[flag] ↦ #b.
+  #[local] Instance : CustomIpat "inv_inner" :=
+    " ( %b
+      & H𝑡_flag
+      )
+    ".
+  Definition waiter_inv t : iProp Σ :=
+    ∃ 𝑡 mtx cond,
+    ⌜t = #𝑡⌝ ∗
+    𝑡.[mutex] ↦□ mtx ∗
+    mutex_inv mtx True ∗
+    𝑡.[condition] ↦□ cond ∗
+    condition_inv cond ∗
+    inv nroot (waiter_inv_inner 𝑡).
+  #[local] Instance : CustomIpat "inv" :=
+    " ( %𝑡
+      & %mtx
+      & %cond
+      & ->
+      & #H𝑡_mutex
+      & #Hmutex_inv
+      & #H𝑡_condition
+      & #Hcondition_inv
+      & #Hinv
+      )
+    ".
+
+  #[global] Instance waiter_inv_persistent t :
+    Persistent (waiter_inv t).
+  Proof.
+    apply _.
+  Qed.
+
+  Lemma waiter_create𑁒spec :
+    {{{
+      True
+    }}}
+      waiter_create ()
+    {{{
+      t
+    , RET t;
+      waiter_inv t
+    }}}.
+  Proof.
+    iIntros "%Φ _ HΦ".
+
+    wp_rec.
+    wp_apply+ (condition_create𑁒spec with "[//]") as "%cond #Hcondition_inv".
+    wp_apply+ (mutex_create𑁒spec True with "[//]") as "%mtx #Hmutex_inv".
+
+    iSteps.
+  Qed.
+
+  Lemma waiter_notify𑁒spec t :
+    {{{
+      waiter_inv t
+    }}}
+      waiter_notify t
+    {{{
+      b
+    , RET #b;
+      True
+    }}}.
+  Proof.
+    iIntros "%Φ (:inv) HΦ".
+
+    wp_rec.
+
+    wp_bind (_.{flag})%E.
+    iInv "Hinv" as "(:inv_inner)".
+    wp_load.
+    destruct b. 1: iSteps.
+    iSplitR "HΦ". { iFrameSteps. }
+    iModIntro.
+
+    wp_load.
+    wp_apply (mutex_lock𑁒spec with "Hmutex_inv") as "(Hmutex_locked & _)".
+    wp_pures.
+
+    wp_bind (_.{flag})%E.
+    iInv "Hinv" as "(:inv_inner)".
+    wp_load.
+    iSplitR "Hmutex_locked HΦ". { iFrameSteps. }
+    iModIntro.
+
+    destruct b; wp_pures.
+
+    - wp_load.
+      wp_apply (mutex_unlock𑁒spec with "[$Hmutex_inv $Hmutex_locked //]") as "_".
+      iSteps.
+
+    - wp_bind (_ <-{flag} _)%E.
+      iInv "Hinv" as "(:inv_inner)".
+      wp_store.
+      iSplitR "Hmutex_locked HΦ". { iFrameSteps. }
+      iModIntro.
+
+      wp_load.
+      wp_apply (mutex_unlock𑁒spec with "[$Hmutex_inv $Hmutex_locked //]") as "_".
+      wp_load.
+      wp_apply (condition_notify𑁒spec with "Hcondition_inv").
+      iSteps.
+  Qed.
+
+  Lemma waiter_prepare_wait𑁒spec t :
+    {{{
+      waiter_inv t
+    }}}
+      waiter_prepare_wait t
+    {{{
+      RET ();
+      True
+    }}}.
+  Proof.
+    iSteps.
+  Qed.
+
+  Lemma waiter_cancel_wait𑁒spec t :
+    {{{
+      waiter_inv t
+    }}}
+      waiter_cancel_wait t
+    {{{
+      RET ();
+      True
+    }}}.
+  Proof.
+    iSteps.
+  Qed.
+
+  Lemma waiter_commit_wait𑁒spec t :
+    {{{
+      waiter_inv t
+    }}}
+      waiter_commit_wait t
+    {{{
+      RET ();
+      True
+    }}}.
+  Proof.
+    iIntros "%Φ (:inv) HΦ".
+
+    wp_rec.
+
+    wp_bind (_.{flag})%E.
+    iInv "Hinv" as "(:inv_inner)".
+    wp_load.
+    destruct b. 1: iSteps.
+    iSplitR "HΦ". { iFrameSteps. }
+    iModIntro.
+
+    wp_load.
+    wp_apply+ (mutex_protect𑁒spec (λ res,
+      ⌜res = ()%V⌝
+    )%I with "[$Hmutex_inv]").
+    { iIntros "Hmutex_locked _".
+      do 2 wp_load.
+      wp_apply (condition_wait_until𑁒spec (λ _, True)%I with "[$Hcondition_inv $Hmutex_inv $Hmutex_locked]").
+      all: iSteps.
+    }
+    iSteps.
+  Qed.
+End waiter_G.
+
+From zoo_parabs Require
+  waiter__opaque.
+
+#[global] Opaque waiter_inv.

--- a/theories/zoo_parabs/waiter__code.v
+++ b/theories/zoo_parabs/waiter__code.v
@@ -17,36 +17,30 @@ Definition waiter_create : val :=
 
 Definition waiter_notify : val :=
   fun: "t" =>
+    mutex_lock "t".{mutex} ;;
     if: "t".{flag} then (
+      mutex_unlock "t".{mutex} ;;
       false
     ) else (
-      mutex_lock "t".{mutex} ;;
-      if: "t".{flag} then (
-        mutex_unlock "t".{mutex} ;;
-        false
-      ) else (
-        "t" <-{flag} true ;;
-        mutex_unlock "t".{mutex} ;;
-        condition_notify "t".{condition} ;;
-        true
-      )
+      "t" <-{flag} true ;;
+      mutex_unlock "t".{mutex} ;;
+      condition_notify "t".{condition} ;;
+      true
     ).
 
 Definition waiter_prepare_wait : val :=
   fun: "t" =>
-    "t" <-{flag} false.
+    mutex_protect "t".{mutex} (fun: <> => "t" <-{flag} false).
 
 Definition waiter_cancel_wait : val :=
   fun: "t" =>
-    "t" <-{flag} true.
+    mutex_protect "t".{mutex} (fun: <> => "t" <-{flag} true).
 
 Definition waiter_commit_wait : val :=
   fun: "t" =>
-    if: ~ "t".{flag} then (
-      mutex_protect "t".{mutex}
-        (fun: <> =>
-           condition_wait_until
-             "t".{condition}
-             "t".{mutex}
-             (fun: <> => "t".{flag}))
-    ).
+    mutex_protect "t".{mutex}
+      (fun: <> =>
+         condition_wait_until
+           "t".{condition}
+           "t".{mutex}
+           (fun: <> => "t".{flag})).

--- a/theories/zoo_parabs/waiter__code.v
+++ b/theories/zoo_parabs/waiter__code.v
@@ -34,7 +34,14 @@ Definition waiter_prepare_wait : val :=
 
 Definition waiter_cancel_wait : val :=
   fun: "t" =>
-    mutex_protect "t".{mutex} (fun: <> => "t" <-{flag} true).
+    mutex_protect "t".{mutex}
+      (fun: <> =>
+         if: "t".{flag} then (
+           false
+         ) else (
+           "t" <-{flag} true ;;
+           true
+         )).
 
 Definition waiter_commit_wait : val :=
   fun: "t" =>

--- a/theories/zoo_parabs/waiter__code.v
+++ b/theories/zoo_parabs/waiter__code.v
@@ -1,0 +1,52 @@
+From zoo Require Import
+  prelude.
+From zoo.language Require Import
+  typeclasses
+  notations.
+From zoo_std Require Import
+  condition
+  mutex.
+From zoo_parabs Require Import
+  waiter__types.
+From zoo Require Import
+  options.
+
+Definition waiter_create : val :=
+  fun: <> =>
+    { mutex_create (), condition_create (), false }.
+
+Definition waiter_notify : val :=
+  fun: "t" =>
+    if: "t".{flag} then (
+      false
+    ) else (
+      mutex_lock "t".{mutex} ;;
+      if: "t".{flag} then (
+        mutex_unlock "t".{mutex} ;;
+        false
+      ) else (
+        "t" <-{flag} true ;;
+        mutex_unlock "t".{mutex} ;;
+        condition_notify "t".{condition} ;;
+        true
+      )
+    ).
+
+Definition waiter_prepare_wait : val :=
+  fun: "t" =>
+    "t" <-{flag} false.
+
+Definition waiter_cancel_wait : val :=
+  fun: "t" =>
+    "t" <-{flag} true.
+
+Definition waiter_commit_wait : val :=
+  fun: "t" =>
+    if: ~ "t".{flag} then (
+      mutex_protect "t".{mutex}
+        (fun: <> =>
+           condition_wait_until
+             "t".{condition}
+             "t".{mutex}
+             (fun: <> => "t".{flag}))
+    ).

--- a/theories/zoo_parabs/waiter__opaque.v
+++ b/theories/zoo_parabs/waiter__opaque.v
@@ -1,0 +1,8 @@
+From zoo_parabs Require Import
+  waiter__code.
+
+#[global] Opaque waiter_create.
+#[global] Opaque waiter_notify.
+#[global] Opaque waiter_prepare_wait.
+#[global] Opaque waiter_cancel_wait.
+#[global] Opaque waiter_commit_wait.

--- a/theories/zoo_parabs/waiter__types.v
+++ b/theories/zoo_parabs/waiter__types.v
@@ -1,0 +1,23 @@
+From zoo Require Import
+  prelude.
+From zoo.language Require Import
+  typeclasses
+  notations.
+From zoo_std Require Import
+  condition
+  mutex.
+From zoo Require Import
+  options.
+
+Notation "'mutex'" := (
+  in_type "zoo_parabs.waiter.t" 0
+)(in custom zoo_field
+).
+Notation "'condition'" := (
+  in_type "zoo_parabs.waiter.t" 1
+)(in custom zoo_field
+).
+Notation "'flag'" := (
+  in_type "zoo_parabs.waiter.t" 2
+)(in custom zoo_field
+).

--- a/theories/zoo_parabs/waiters.v
+++ b/theories/zoo_parabs/waiters.v
@@ -5,27 +5,29 @@ From zoo.language Require Import
 From zoo.diaframe Require Import
   diaframe.
 From zoo_std Require Import
-  option
-  mpsc_waiter.
+  array.
 From zoo_saturn Require Import
   mpmc_queue_1.
 From zoo_parabs Require Export
   base
   waiters__code.
+From zoo_parabs Require Import
+  waiter
+  waiters__types.
 From zoo Require Import
   options.
 
-Implicit Types b : bool.
-Implicit Types v t : val.
+Implicit Types v t waiters queue : val.
+Implicit Types 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 𝑞𝑢𝑒𝑢𝑒 : list val.
 
 Class WaitersG Σ `{zoo_G : !ZooG Σ} :=
   { #[local] waiters_G_queue_G :: MpmcQueue1G Σ
-  ; #[local] waiters_G_waiter_G :: MpscWaiterG Σ
+  ; #[local] waiters_G_waiter_G :: WaiterG Σ
   }.
 
 Definition waiters_Σ := #[
   mpmc_queue_1_Σ ;
-  mpsc_waiter_Σ
+  waiter_Σ
 ].
 #[global] Instance subG_ws_hub_Σ Σ `{zoo_G : !ZooG Σ} :
   subG waiters_Σ Σ →
@@ -37,175 +39,196 @@ Qed.
 Section waiters_G.
   Context `{waiters_G : WaitersG Σ}.
 
-  #[local] Definition waiters_inv_inner t : iProp Σ :=
-    ∃ waiters,
-    mpmc_queue_1_model t waiters ∗
-    [∗ list] waiter ∈ waiters,
-      mpsc_waiter_inv waiter True.
-  Definition waiters_inv t : iProp Σ :=
-    mpmc_queue_1_inv t (nroot.@"queue") ∗
-    inv (nroot.@"inv") (waiters_inv_inner t).
+  #[local] Definition waiters_inv_inner queue : iProp Σ :=
+    ∃ 𝑞𝑢𝑒𝑢𝑒,
+    mpmc_queue_1_model queue 𝑞𝑢𝑒𝑢𝑒 ∗
+    [∗ list] 𝑤𝑎𝑖𝑡𝑒𝑟 ∈ 𝑞𝑢𝑒𝑢𝑒,
+      waiter_inv 𝑤𝑎𝑖𝑡𝑒𝑟.
+  #[local] Instance : CustomIpat "inv_inner" :=
+    " ( %𝑞𝑢𝑒𝑢𝑒
+      & >Hqueue_model
+      & H𝑞𝑢𝑒𝑢𝑒
+      )
+    ".
+  Definition waiters_inv t sz : iProp Σ :=
+    ∃ waiters 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 queue,
+    ⌜t = (waiters, queue)%V⌝ ∗
+    array_model waiters Discard 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 ∗
+    ⌜length 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 = sz⌝ ∗
+    ([∗ list] 𝑤𝑎𝑖𝑡𝑒𝑟 ∈ 𝑤𝑎𝑖𝑡𝑒𝑟𝑠, waiter_inv 𝑤𝑎𝑖𝑡𝑒𝑟) ∗
+    mpmc_queue_1_inv queue (nroot.@"queue") ∗
+    inv (nroot.@"inv") (waiters_inv_inner queue).
+  #[local] Instance : CustomIpat "inv" :=
+    " ( %waiters
+      & %𝑤𝑎𝑖𝑡𝑒𝑟𝑠
+      & %queue
+      & ->
+      & #Hwaiters
+      & %H𝑤𝑎𝑖𝑡𝑒𝑟s
+      & #H𝑤𝑎𝑖𝑡𝑒𝑟𝑠
+      & #Hqueue_inv
+      & #Hinv
+      )
+    ".
 
-  Definition waiters_waiter t waiter : iProp Σ :=
-    mpsc_waiter_inv waiter True ∗
-    mpsc_waiter_consumer waiter.
-
-  #[global] Instance waiters_inv_persistent t :
-    Persistent (waiters_inv t).
+  #[global] Instance waiters_inv_persistent t sz :
+    Persistent (waiters_inv t sz).
   Proof.
     apply _.
   Qed.
 
-  Lemma waiters_waiter_exclusive t1 t2 waiter :
-    waiters_waiter t1 waiter -∗
-    waiters_waiter t2 waiter -∗
-    False.
-  Proof.
-    iIntros "(_ & Hwaiter_consumer1) (_ & Hwaiter_consumer2)".
-    iApply (mpsc_waiter_consumer_exclusive with "Hwaiter_consumer1 Hwaiter_consumer2").
-  Qed.
-
-  Lemma waiters_create𑁒spec :
+  Lemma waiters_create𑁒spec sz :
+    (0 ≤ sz)%Z →
     {{{
       True
     }}}
-      waiters_create ()
+      waiters_create #sz
     {{{
       t
     , RET t;
-      waiters_inv t
+      waiters_inv t ₊sz
     }}}.
   Proof.
-    iIntros "%Φ _ HΦ".
+    iIntros "%Hsz %Φ _ HΦ".
 
-    iApply wp_fupd.
+    wp_rec.
     wp_apply (mpmc_queue_1_create𑁒spec with "[//]") as (t) "(#Hqueue_inv & Hmodel)".
+
+    wp_apply (array_unsafe_init𑁒spec_disentangled (λ _ 𝑤𝑎𝑖𝑡𝑒𝑟,
+      waiter_inv 𝑤𝑎𝑖𝑡𝑒𝑟
+    )%I) as (waiters 𝑤𝑎𝑖𝑡𝑒𝑟𝑠) "(%H𝑤𝑎𝑖𝑡𝑒𝑟𝑠 & Hwaiters & H𝑤𝑎𝑖𝑡𝑒𝑟𝑠)". 1: done.
+    { iIntros "!> %i %Hi".
+      wp_apply (waiter_create𑁒spec with "[//]").
+      iSteps.
+    }
+    iMod (array_model_persist with "Hwaiters") as "#Hwaiters".
+
     iSteps.
   Qed.
 
-  #[local] Lemma waiters_notify'𑁒spec t :
+  Lemma waiters_notify_one𑁒spec t sz :
     {{{
-      waiters_inv t
+      waiters_inv t sz
     }}}
-      waiters_notify' t
+      waiters_notify_one t
     {{{
-      b
-    , RET #b;
+      RET ();
       True
     }}}.
   Proof.
-    iIntros "%Φ (#Hqueue_inv & #Hinv) HΦ".
+    iIntros "%Φ (:inv) HΦ".
 
     iLöb as "HLöb".
 
     wp_rec.
 
-    awp_apply (mpmc_queue_1_pop𑁒spec with "Hqueue_inv") without "HΦ".
-    iInv "Hinv" as "(%waiters & >Hmodel & Hwaiters)".
-    iAaccIntro with "Hmodel"; first iSteps. iIntros "Hmodel !>".
-    destruct waiters as [| waiter waiters]; first iSteps.
-    iDestruct "Hwaiters" as "(Hwaiter & Hwaiters)".
-    iSplitR "Hwaiter"; first iSteps.
+    awp_apply+ (mpmc_queue_1_pop𑁒spec with "Hqueue_inv") without "HΦ".
+    iInv "Hinv" as "(:inv_inner)".
+    iAaccIntro with "Hqueue_model". 1: iSteps. iIntros "Hqueue_model !>".
+    destruct 𝑞𝑢𝑒𝑢𝑒 as [| 𝑤𝑎𝑖𝑡𝑒𝑟 𝑞𝑢𝑒𝑢𝑒]. 1: iSteps.
+    iDestruct "H𝑞𝑢𝑒𝑢𝑒" as "(H𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑞𝑢𝑒𝑢𝑒)".
+    iSplitR "H𝑤𝑎𝑖𝑡𝑒𝑟". { iFrame. }
     iIntros "_ HΦ".
 
-    wp_apply+ (mpsc_waiter_notify𑁒spec with "[$Hwaiter //]") as ([]) "_"; last iSteps.
+    wp_apply+ (waiter_notify𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟") as ([]) "_". 1: iSteps.
     wp_apply+ ("HLöb" with "HΦ").
   Qed.
 
-  Lemma waiters_notify𑁒spec t :
+  Lemma waiters_notify_all𑁒spec t sz :
     {{{
-      waiters_inv t
+      waiters_inv t sz
     }}}
-      waiters_notify t
+      waiters_notify_all t
     {{{
       RET ();
       True
     }}}.
   Proof.
-    iIntros "%Φ #Hinv HΦ".
+    iIntros "%Φ (:inv) HΦ".
+
+    iLöb as "HLöb".
 
     wp_rec.
-    wp_apply (waiters_notify'𑁒spec with "Hinv").
+
+    awp_apply+ (mpmc_queue_1_pop𑁒spec with "Hqueue_inv") without "HΦ".
+    iInv "Hinv" as "(:inv_inner)".
+    iAaccIntro with "Hqueue_model". 1: iSteps. iIntros "Hqueue_model !>".
+    destruct 𝑞𝑢𝑒𝑢𝑒 as [| 𝑤𝑎𝑖𝑡𝑒𝑟 𝑞𝑢𝑒𝑢𝑒]. 1: iSteps.
+    iDestruct "H𝑞𝑢𝑒𝑢𝑒" as "(H𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑞𝑢𝑒𝑢𝑒)".
+    iSplitR "H𝑤𝑎𝑖𝑡𝑒𝑟". { iFrame. }
+    iIntros "_ HΦ".
+
+    wp_apply+ (waiter_notify𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟") as (res) "_".
+    wp_apply+ ("HLöb" with "HΦ").
+  Qed.
+
+  Lemma waiters_prepare_wait𑁒spec t (sz : nat) i :
+    (0 ≤ i < sz)%Z →
+    {{{
+      waiters_inv t sz
+    }}}
+      waiters_prepare_wait t #i
+    {{{
+      RET ();
+      True
+    }}}.
+  Proof.
+    iIntros "%Hi %Φ (:inv) HΦ".
+
+    destruct (lookup_lt_is_Some_2 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 ₊i) as (𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑤𝑎𝑖𝑡𝑒𝑟𝑠_lookup). 1: lia.
+    iDestruct (big_sepL_lookup with "H𝑤𝑎𝑖𝑡𝑒𝑟𝑠") as "H𝑤𝑎𝑖𝑡𝑒𝑟". 1: done.
+
+    wp_rec.
+    wp_apply+ (array_unsafe_get𑁒spec with "Hwaiters") as "_". 1-3: done || lia.
+    wp_apply+ (waiter_prepare_wait𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟") as "_".
+
+    awp_apply+ (mpmc_queue_1_push𑁒spec with "Hqueue_inv") without "HΦ".
+    iInv "Hinv" as "(:inv_inner)".
+    iAaccIntro with "Hqueue_model". 1: iSteps. iIntros "Hqueue_model !>".
+    iSplitL. { iFrameSteps. }
     iSteps.
   Qed.
 
-  Lemma waiters_notify_many𑁒spec t n :
-    (0 ≤ n)%Z →
+  Lemma waiters_cancel_wait𑁒spec t (sz : nat) i :
+    (0 ≤ i < sz)%Z →
     {{{
-      waiters_inv t
+      waiters_inv t sz
     }}}
-      waiters_notify_many t #n
+      waiters_cancel_wait t #i
     {{{
       RET ();
       True
     }}}.
   Proof.
-    iIntros "%Hn %Φ #Hinv HΦ".
+    iIntros "%Hi %Φ (:inv) HΦ".
 
-    iLöb as "HLöb" forall (n Hn).
-
-    wp_rec. wp_pures.
-    case_bool_decide; last iSteps.
-    wp_apply+ (waiters_notify'𑁒spec with "Hinv") as ([]) "_"; last iSteps.
-    wp_apply+ ("HLöb" with "[] HΦ"); first iSteps.
-  Qed.
-
-  Lemma waiters_prepare_wait𑁒spec t :
-    {{{
-      waiters_inv t
-    }}}
-      waiters_prepare_wait t
-    {{{
-      waiter
-    , RET waiter;
-      waiters_waiter t waiter
-    }}}.
-  Proof.
-    iIntros "%Φ (#Hqueue_inv & #Hinv) HΦ".
+    destruct (lookup_lt_is_Some_2 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 ₊i) as (𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑤𝑎𝑖𝑡𝑒𝑟𝑠_lookup). 1: lia.
+    iDestruct (big_sepL_lookup with "H𝑤𝑎𝑖𝑡𝑒𝑟𝑠") as "H𝑤𝑎𝑖𝑡𝑒𝑟". 1: done.
 
     wp_rec.
-    wp_apply (mpsc_waiter_create𑁒spec with "[//]") as (waiter) "(#Hwaiter_inv & Hwaiter_consumer)".
-
-    awp_apply+ (mpmc_queue_1_push𑁒spec with "Hqueue_inv") without "Hwaiter_consumer HΦ".
-    iInv "Hinv" as "(%waiters & >Hmodel & Hwaiters)".
-    iAaccIntro with "Hmodel"; first iSteps. iIntros "Hmodel !>".
-    iSplitL. { iSteps. iApply big_sepL_snoc. iSteps. }
-    iSteps.
+    wp_apply+ (array_unsafe_get𑁒spec with "Hwaiters") as "_". 1-3: done || lia.
+    wp_apply+ (waiter_cancel_wait𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟 HΦ").
   Qed.
 
-  Lemma waiters_cancel_wait𑁒spec t waiter :
+  Lemma waiters_commit_wait𑁒spec t (sz : nat) i :
+    (0 ≤ i < sz)%Z →
     {{{
-      waiters_inv t ∗
-      waiters_waiter t waiter
+      waiters_inv t sz
     }}}
-      waiters_cancel_wait t waiter
+      waiters_commit_wait t #i
     {{{
       RET ();
       True
     }}}.
   Proof.
-    iIntros "%Φ (#Hinv & (#Hwaiter_inv & Hwaiter_consumer)) HΦ".
+    iIntros "%Hi %Φ (:inv) HΦ".
+
+    destruct (lookup_lt_is_Some_2 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 ₊i) as (𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑤𝑎𝑖𝑡𝑒𝑟𝑠_lookup). 1: lia.
+    iDestruct (big_sepL_lookup with "H𝑤𝑎𝑖𝑡𝑒𝑟𝑠") as "H𝑤𝑎𝑖𝑡𝑒𝑟". 1: done.
 
     wp_rec.
-    wp_apply+ (mpsc_waiter_notify𑁒spec with "[$Hwaiter_inv //]") as ([]) "_"; last iSteps.
-    wp_apply+ (waiters_notify𑁒spec with "Hinv HΦ").
-  Qed.
-
-  Lemma waiters_commit_wait𑁒spec t waiter :
-    {{{
-      waiters_inv t ∗
-      waiters_waiter t waiter
-    }}}
-      waiters_commit_wait t waiter
-    {{{
-      RET ();
-      True
-    }}}.
-  Proof.
-    iIntros "%Φ (#Hinv & (#Hwaiter_inv & Hwaiter_consumer)) HΦ".
-
-    wp_rec.
-    wp_apply+ (mpsc_waiter_wait𑁒spec with "[$Hwaiter_inv $Hwaiter_consumer] HΦ").
+    wp_apply+ (array_unsafe_get𑁒spec with "Hwaiters") as "_". 1-3: done || lia.
+    wp_apply+ (waiter_commit_wait𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟 HΦ").
   Qed.
 End waiters_G.
 
@@ -213,4 +236,3 @@ From zoo_parabs Require
   waiters__opaque.
 
 #[global] Opaque waiters_inv.
-#[global] Opaque waiters_waiter.

--- a/theories/zoo_parabs/waiters.v
+++ b/theories/zoo_parabs/waiters.v
@@ -106,6 +106,27 @@ Section waiters_G.
     iSteps.
   Qed.
 
+  Lemma waiters_notify𑁒spec t (sz : nat) i :
+    (0 ≤ i < sz)%Z →
+    {{{
+      waiters_inv t sz
+    }}}
+      waiters_notify t #i
+    {{{
+      RET ();
+      True
+    }}}.
+  Proof.
+    iIntros "%Hi %Φ (:inv) HΦ".
+
+    destruct (lookup_lt_is_Some_2 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 ₊i) as (𝑤𝑎𝑖𝑡𝑒𝑟 & H𝑤𝑎𝑖𝑡𝑒𝑟𝑠_lookup). 1: lia.
+    iDestruct (big_sepL_lookup with "H𝑤𝑎𝑖𝑡𝑒𝑟𝑠") as "H𝑤𝑎𝑖𝑡𝑒𝑟". 1: done.
+
+    wp_rec.
+    wp_apply+ (array_unsafe_get𑁒spec with "Hwaiters") as "_". 1-3: done || lia.
+    wp_apply+ (waiter_notify_strong𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟 HΦ").
+  Qed.
+
   Lemma waiters_notify_one𑁒spec t sz :
     {{{
       waiters_inv t sz

--- a/theories/zoo_parabs/waiters.v
+++ b/theories/zoo_parabs/waiters.v
@@ -17,6 +17,7 @@ From zoo_parabs Require Import
 From zoo Require Import
   options.
 
+Implicit Types b : bool.
 Implicit Types v t waiters queue : val.
 Implicit Types 𝑤𝑎𝑖𝑡𝑒𝑟𝑠 𝑞𝑢𝑒𝑢𝑒 : list val.
 
@@ -124,7 +125,8 @@ Section waiters_G.
 
     wp_rec.
     wp_apply+ (array_unsafe_get𑁒spec with "Hwaiters") as "_". 1-3: done || lia.
-    wp_apply+ (waiter_notify_strong𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟 HΦ").
+    wp_apply+ (waiter_notify𑁒spec with "H𝑤𝑎𝑖𝑡𝑒𝑟").
+    iSteps.
   Qed.
 
   Lemma waiters_notify_one𑁒spec t sz :
@@ -217,7 +219,8 @@ Section waiters_G.
     }}}
       waiters_cancel_wait t #i
     {{{
-      RET ();
+      b
+    , RET #b;
       True
     }}}.
   Proof.

--- a/theories/zoo_parabs/waiters__code.v
+++ b/theories/zoo_parabs/waiters__code.v
@@ -3,54 +3,54 @@ From zoo Require Import
 From zoo.language Require Import
   typeclasses
   notations.
+From zoo_parabs Require Import
+  waiter.
 From zoo_saturn Require Import
   mpmc_queue_1.
 From zoo_std Require Import
-  mpsc_waiter.
+  array.
 From zoo_parabs Require Import
   waiters__types.
 From zoo Require Import
   options.
 
 Definition waiters_create : val :=
-  mpmc_queue_1_create.
+  fun: "sz" =>
+    (array_unsafe_init "sz" waiter_create, mpmc_queue_1_create ()).
 
-Definition waiters_notify' : val :=
-  rec: "notify'" "t" =>
-    match: mpmc_queue_1_pop "t" with
+Definition waiters_notify_one : val :=
+  rec: "notify_one" "t" =>
+    match: mpmc_queue_1_pop "t".<queue> with
     | None =>
-        false
+        ()
     | Some "waiter" =>
-        if: mpsc_waiter_notify "waiter" then (
-          "notify'" "t"
-        ) else (
-          true
+        if: ~ waiter_notify "waiter" then (
+          "notify_one" "t"
         )
     end.
 
-Definition waiters_notify : val :=
-  fun: "t" =>
-    waiters_notify' "t" ;;
-    ().
-
-Definition waiters_notify_many : val :=
-  rec: "notify_many" "t" "n" =>
-    if: 0 < "n" and waiters_notify' "t" then (
-      "notify_many" "t" ("n" - 1)
-    ).
+Definition waiters_notify_all : val :=
+  rec: "notify_all" "t" =>
+    match: mpmc_queue_1_pop "t".<queue> with
+    | None =>
+        ()
+    | Some "waiter" =>
+        waiter_notify "waiter" ;;
+        "notify_all" "t"
+    end.
 
 Definition waiters_prepare_wait : val :=
-  fun: "t" =>
-    let: "waiter" := mpsc_waiter_create () in
-    mpmc_queue_1_push "t" "waiter" ;;
-    "waiter".
+  fun: "t" "i" =>
+    let: "waiter" := array_unsafe_get "t".<waiters> "i" in
+    waiter_prepare_wait "waiter" ;;
+    mpmc_queue_1_push "t".<queue> "waiter".
 
 Definition waiters_cancel_wait : val :=
-  fun: "t" "waiter" =>
-    if: mpsc_waiter_notify "waiter" then (
-      waiters_notify "t"
-    ).
+  fun: "t" "i" =>
+    let: "waiter" := array_unsafe_get "t".<waiters> "i" in
+    waiter_cancel_wait "waiter".
 
 Definition waiters_commit_wait : val :=
-  fun: "_t" "waiter" =>
-    mpsc_waiter_wait "waiter".
+  fun: "t" "i" =>
+    let: "waiter" := array_unsafe_get "t".<waiters> "i" in
+    waiter_commit_wait "waiter".

--- a/theories/zoo_parabs/waiters__code.v
+++ b/theories/zoo_parabs/waiters__code.v
@@ -21,7 +21,8 @@ Definition waiters_create : val :=
 Definition waiters_notify : val :=
   fun: "t" "i" =>
     let: "waiter" := array_unsafe_get "t".<waiters> "i" in
-    waiter_notify_strong "waiter".
+    waiter_notify "waiter" ;;
+    ().
 
 Definition waiters_notify_one : val :=
   rec: "notify_one" "t" =>

--- a/theories/zoo_parabs/waiters__code.v
+++ b/theories/zoo_parabs/waiters__code.v
@@ -18,6 +18,11 @@ Definition waiters_create : val :=
   fun: "sz" =>
     (array_unsafe_init "sz" waiter_create, mpmc_queue_1_create ()).
 
+Definition waiters_notify : val :=
+  fun: "t" "i" =>
+    let: "waiter" := array_unsafe_get "t".<waiters> "i" in
+    waiter_notify_strong "waiter".
+
 Definition waiters_notify_one : val :=
   rec: "notify_one" "t" =>
     match: mpmc_queue_1_pop "t".<queue> with

--- a/theories/zoo_parabs/waiters__opaque.v
+++ b/theories/zoo_parabs/waiters__opaque.v
@@ -2,8 +2,8 @@ From zoo_parabs Require Import
   waiters__code.
 
 #[global] Opaque waiters_create.
-#[global] Opaque waiters_notify.
-#[global] Opaque waiters_notify_many.
+#[global] Opaque waiters_notify_one.
+#[global] Opaque waiters_notify_all.
 #[global] Opaque waiters_prepare_wait.
 #[global] Opaque waiters_cancel_wait.
 #[global] Opaque waiters_commit_wait.

--- a/theories/zoo_parabs/waiters__opaque.v
+++ b/theories/zoo_parabs/waiters__opaque.v
@@ -2,6 +2,7 @@ From zoo_parabs Require Import
   waiters__code.
 
 #[global] Opaque waiters_create.
+#[global] Opaque waiters_notify.
 #[global] Opaque waiters_notify_one.
 #[global] Opaque waiters_notify_all.
 #[global] Opaque waiters_prepare_wait.

--- a/theories/zoo_parabs/waiters__types.v
+++ b/theories/zoo_parabs/waiters__types.v
@@ -3,10 +3,20 @@ From zoo Require Import
 From zoo.language Require Import
   typeclasses
   notations.
+From zoo_parabs Require Import
+  waiter.
 From zoo_saturn Require Import
   mpmc_queue_1.
 From zoo_std Require Import
-  mpsc_waiter.
+  array.
 From zoo Require Import
   options.
 
+Notation "'waiters'" := (
+  in_type "zoo_parabs.waiters.t" 0
+)(in custom zoo_proj
+).
+Notation "'queue'" := (
+  in_type "zoo_parabs.waiters.t" 1
+)(in custom zoo_proj
+).

--- a/theories/zoo_parabs/ws_hub_fifo.v
+++ b/theories/zoo_parabs/ws_hub_fifo.v
@@ -27,7 +27,7 @@ From zoo Require Import
 
 Implicit Types b closed : bool.
 Implicit Types num_active : Z.
-Implicit Types l : location.
+Implicit Types 𝑡 : location.
 Implicit Types v t until pred : val.
 Implicit Types ws : list val.
 Implicit Types vs : gmultiset val.
@@ -106,15 +106,17 @@ Section ws_hub_fifo_G.
     solve_countable.
   Qed.
 
-  #[local] Definition owner' γ_owners i : iProp Σ :=
+  #[local] Definition owner' γ_owners sz i : iProp Σ :=
     ∃ γ_owner,
     ⌜γ_owners !! i = Some γ_owner⌝ ∗
+    ⌜length γ_owners = sz⌝ ∗
     excl γ_owner ().
   #[local] Definition owner γ i :=
-    owner' γ.(metadata_owners) i.
+    owner' γ.(metadata_owners) γ.(metadata_size) i.
   #[local] Instance : CustomIpat "owner_" :=
     " ( %γ_owner{}
       & %Hlookup{}
+      & %Hlength{_{}}
       & Howner{}
       )
     ".
@@ -141,34 +143,34 @@ Section ws_hub_fifo_G.
   #[local] Definition emptiness_at γ :=
     emptiness_at' γ.(metadata_emptiness).
 
-  #[local] Definition inv_inner l : iProp Σ :=
+  #[local] Definition inv_inner 𝑡 : iProp Σ :=
     ∃ num_active,
-    l.[num_active] ↦ #num_active.
+    𝑡.[num_active] ↦ #num_active.
   #[local] Instance : CustomIpat "inv_inner" :=
     " ( %num_active
-      & Hl_num_active
+      & H𝑡_num_active
       )
     ".
   Definition ws_hub_fifo_inv t ι (sz : nat) : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
     ⌜sz = γ.(metadata_size)⌝ ∗
-    meta l nroot γ ∗
-    l.[size] ↦□ #γ.(metadata_size) ∗
-    l.[queue] ↦□ γ.(metadata_queue) ∗
-    l.[waiters] ↦□ γ.(metadata_waiters) ∗
+    meta 𝑡 nroot γ ∗
+    𝑡.[size] ↦□ #γ.(metadata_size) ∗
+    𝑡.[queue] ↦□ γ.(metadata_queue) ∗
+    𝑡.[waiters] ↦□ γ.(metadata_waiters) ∗
     mpmc_queue_1_inv γ.(metadata_queue) ι ∗
-    waiters_inv γ.(metadata_waiters) ∗
-    inv nroot (inv_inner l).
+    waiters_inv γ.(metadata_waiters) sz ∗
+    inv nroot (inv_inner 𝑡).
   #[local] Instance : CustomIpat "inv" :=
-    " ( %l{}
+    " ( %𝑡{}
       & %γ{}
       & {%Heq{};->}
       & ->
       & #Hmeta{}
-      & #Hl{}_size
-      & #Hl{}_queue
-      & #Hl{}_waiters
+      & #H𝑡{}_size
+      & #H𝑡{}_queue
+      & #H𝑡{}_waiters
       & #Hqueue{}_inv
       & #Hwaiters{}_inv
       & #Hinv{}
@@ -176,9 +178,9 @@ Section ws_hub_fifo_G.
     ".
 
   Definition ws_hub_fifo_model t vs : iProp Σ :=
-    ∃ l γ ws,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ ws,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     mpmc_queue_1_model γ.(metadata_queue) ws ∗
     ⌜consistent vs ws⌝ ∗
     emptiness_auth γ vs.
@@ -195,13 +197,13 @@ Section ws_hub_fifo_G.
     ".
 
   Definition ws_hub_fifo_owner t i status empty : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     owner γ i ∗
     emptiness_at γ i empty.
   #[local] Instance : CustomIpat "owner" :=
-    " ( %l{;_}
+    " ( %𝑡{;_}
       & %γ{;_}
       & %Heq{}
       & #Hmeta_{}
@@ -226,7 +228,7 @@ Section ws_hub_fifo_G.
     ⊢ |==>
       ∃ γ_owners,
       [∗ list] i ∈ seq 0 sz,
-        owner' γ_owners i.
+        owner' γ_owners sz i.
   Proof.
     iAssert (
       [∗ list] _ ∈ seq 0 sz,
@@ -238,11 +240,21 @@ Section ws_hub_fifo_G.
       iApply excl_alloc.
     }
     iMod (big_sepL_bupd with "H") as "H".
-    iDestruct (big_sepL_exists with "H") as "(%γ_owners & _ & H)".
+    iDestruct (big_sepL_exists with "H") as "(%γ_owners & %Hlength & H)".
+    iDestruct (big_sepL2_intro (λ _ _ _, ⌜length γ_owners = sz⌝)%I (seq 0 sz) γ_owners with "[%]") as "Hlength". 1: done.
+    { simpl_length in Hlength. naive_solver. }
+    iDestruct (big_sepL2_sep_2 with "Hlength H") as "H".
     iDestruct (big_sepL2_retract_r with "H") as "(_ & H)".
     iDestruct (big_sepL_seq_index_2 with "H") as "H".
     { simpl_length. }
     iSteps.
+  Qed.
+  #[local] Lemma owner_valid γ i :
+    owner γ i ⊢
+    ⌜i < γ.(metadata_size)⌝.
+  Proof.
+    iIntros "(:owner_)". iPureIntro.
+    rewrite -Hlength. eapply lookup_lt_Some => //.
   Qed.
   #[local] Lemma owner_exclusive γ i :
     owner γ i -∗
@@ -265,6 +277,15 @@ Section ws_hub_fifo_G.
     iMod ghost_list_alloc as "(%γ_emptiness & $ & Hats)".
     iDestruct (big_sepL_replicate_1 with "Hats") as "$".
     iSteps. iPureIntro. simpl_length.
+  Qed.
+  #[local] Lemma emptiness_at_valid γ vs i empty :
+    emptiness_auth γ vs -∗
+    emptiness_at γ i empty -∗
+    ⌜i < γ.(metadata_size)⌝.
+  Proof.
+    iIntros "(:emptiness_auth) Hat".
+    iDestruct (ghost_list_lookup with "Hauth Hat") as %Hi%lookup_lt_Some.
+    iSteps.
   Qed.
   #[local] Lemma emptiness_empty γ vs :
     emptiness_auth γ vs -∗
@@ -321,7 +342,7 @@ Section ws_hub_fifo_G.
     ⌜sz1 = sz2⌝.
   Proof.
     iIntros "(:inv =1) (:inv =2)". simplify.
-    iDestruct (pointsto_agree with "Hl1_size Hl2_size") as %[=].
+    iDestruct (pointsto_agree with "H𝑡1_size H𝑡2_size") as %[=].
     iSteps.
   Qed.
 
@@ -333,6 +354,16 @@ Section ws_hub_fifo_G.
     iIntros "(:owner =1) (:owner =2)". simplify.
     iDestruct (meta_agree with "Hmeta_1 Hmeta_2") as %->.
     iApply (owner_exclusive with "Howner_1 Howner_2").
+  Qed.
+
+  Lemma ws_hub_fifo_inv_owner t ι sz i status empty :
+    ws_hub_fifo_inv t ι sz -∗
+    ws_hub_fifo_owner t i status empty -∗
+    ⌜i < sz⌝.
+  Proof.
+    iIntros "(:inv) (:owner)". simplify.
+    iDestruct (meta_agree with "Hmeta Hmeta_") as %<-.
+    iApply (owner_valid with "Howner").
   Qed.
 
   Lemma ws_hub_fifo_model_empty t ι sz vs :
@@ -370,12 +401,12 @@ Section ws_hub_fifo_G.
     iIntros "%Hsz %Φ _ HΦ".
 
     wp_rec.
-    wp_apply+ (waiters_create𑁒spec with "[//]") as (waiters) "#Hwaiters_inv".
+    wp_apply+ (waiters_create𑁒spec with "[//]") as (waiters) "#Hwaiters_inv". 1: done.
     wp_apply (mpmc_queue_1_create𑁒spec with "[//]") as (queue) "(#Hqueue_inv & Hqueue_model)".
-    wp_block l as "Hmeta" "(Hl_size & Hl_queue & Hl_waiters & Hl_num_active & _)".
-    iMod (pointsto_persist with "Hl_size") as "#Hl_size".
-    iMod (pointsto_persist with "Hl_queue") as "#Hl_queue".
-    iMod (pointsto_persist with "Hl_waiters") as "#Hl_waiters".
+    wp_block 𝑡 as "Hmeta" "(H𝑡_size & H𝑡_queue & H𝑡_waiters & H𝑡_num_active & _)".
+    iMod (pointsto_persist with "H𝑡_size") as "#H𝑡_size".
+    iMod (pointsto_persist with "H𝑡_queue") as "#H𝑡_queue".
+    iMod (pointsto_persist with "H𝑡_waiters") as "#H𝑡_waiters".
 
     iMod owner_alloc as "(%γ_owners & Howners)".
     iMod (emptiness_alloc ₊sz) as "(%γ_emptiness & Hemptiness_auth & Hemptiness_ats)".
@@ -391,8 +422,8 @@ Section ws_hub_fifo_G.
     iMod (meta_set γ with "Hmeta") as "#Hmeta"; first done.
 
     iApply "HΦ".
-    iSplitL "Hl_num_active".
-    { iExists l, γ. iSteps. }
+    iSplitL "H𝑡_num_active".
+    { iExists 𝑡, γ. iSteps. }
     iSplitL "Hqueue_model Hemptiness_auth".
     { iSteps. }
     iDestruct (big_sepL_sep_2 with "Howners Hemptiness_ats") as "Howners".
@@ -504,7 +535,7 @@ Section ws_hub_fifo_G.
     iIntros "%Φ (:inv) HΦ".
 
     wp_rec. wp_load.
-    wp_apply (waiters_notify𑁒spec with "Hwaiters_inv HΦ").
+    wp_apply (waiters_notify_one𑁒spec with "Hwaiters_inv HΦ").
   Qed.
 
   #[local] Lemma ws_hub_fifo_notify_all𑁒spec t ι sz :
@@ -519,10 +550,8 @@ Section ws_hub_fifo_G.
   Proof.
     iIntros "%Φ (:inv) HΦ".
 
-    wp_rec.
-    wp_apply (ws_hub_fifo_size𑁒spec) as "_"; first iSteps.
-    wp_load.
-    wp_apply (waiters_notify_many𑁒spec with "Hwaiters_inv HΦ"); first lia.
+    wp_rec. wp_load.
+    wp_apply (waiters_notify_all𑁒spec with "Hwaiters_inv HΦ").
   Qed.
 
   Lemma ws_hub_fifo_push𑁒spec t ι sz i i_ empty v :
@@ -611,7 +640,7 @@ Section ws_hub_fifo_G.
         | None =>
             True
         | Some (i, empty) =>
-            ws_hub_fifo_owner #l i Nonblocked Empty
+            ws_hub_fifo_owner #𝑡 i Nonblocked Empty
         end
       )%I with "[> Hemptiness_auth Howner]" as "(Hemptiness_auth & Howner)".
       { destruct owner as [(i, empty) |]; last iSteps.
@@ -803,13 +832,14 @@ Section ws_hub_fifo_G.
     iApply ("HΦ" with "[$Howner $H]").
   Qed.
 
-  #[local] Lemma ws_hub_fifo_steal₀𑁒spec t ι sz :
+  #[local] Lemma ws_hub_fifo_steal₀𑁒spec t ι (sz : nat) i :
+    (0 ≤ i < sz)%Z →
     <<<
       ws_hub_fifo_inv t ι sz
     | ∀∀ vs,
       ws_hub_fifo_model t vs
     >>>
-      ws_hub_fifo_steal₀ t @ ↑ι
+      ws_hub_fifo_steal₀ t #i @ ↑ι
     <<<
       ∃∃ o,
       match o with
@@ -824,13 +854,13 @@ Section ws_hub_fifo_G.
       True
     >>>.
   Proof.
-    iIntros "%Φ (:inv) HΦ".
+    iIntros "%Hi %Φ (:inv) HΦ".
 
     iLöb as "HLöb".
 
     wp_rec. wp_load.
-    wp_apply+ (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as (waiter) "Hwaiter".
-    wp_apply+ ws_hub_fifo_closed𑁒spec as ([]) "_"; first iSteps.
+    wp_apply+ (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as "_". 1: done.
+    wp_apply+ ws_hub_fifo_closed𑁒spec as ([]) "_". 1: iSteps.
 
     - wp_apply+ ws_hub_fifo_notify_all𑁒spec as "_"; first iSteps.
       wp_pures.
@@ -843,10 +873,11 @@ Section ws_hub_fifo_G.
       wp_apply+ (mpmc_queue_1_is_empty𑁒spec' with "Hqueue_inv") as (b) "_".
 
       wp_bind (if: _ then _ else _)%E.
-      wp_apply (wp_wand itype_unit with "[Hwaiter]") as (res) "->".
+      wp_apply (wp_wand itype_unit) as (res) "->".
       { destruct b; wp_pures.
-        1: wp_apply (waiters_commit_wait𑁒spec with "[$Hwaiters_inv $Hwaiter]").
-        2: wp_apply (waiters_cancel_wait𑁒spec with "[$Hwaiters_inv $Hwaiter]").
+        all: wp_load.
+        1: wp_apply (waiters_commit_wait𑁒spec with "Hwaiters_inv"); first done.
+        2: wp_apply (waiters_cancel_wait𑁒spec with "Hwaiters_inv"); first done.
         all: iSteps.
       }
 
@@ -887,10 +918,11 @@ Section ws_hub_fifo_G.
     >>>.
   Proof.
     iIntros (-> Hmax_round_noyield Hmax_round_yield) "%Φ (#Hinv & Howner) HΦ".
+    iDestruct (ws_hub_fifo_inv_owner with "Hinv Howner") as %Hi.
 
     wp_rec.
     wp_apply+ (ws_hub_fifo_begin_inactive𑁒spec with "Hinv") as "_".
-    wp_apply+ (ws_hub_fifo_steal₀𑁒spec with "Hinv").
+    wp_apply+ (ws_hub_fifo_steal₀𑁒spec with "Hinv"). 1: lia.
     iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ HP".
     iApply ("HΦ" with "[$Howner $HP]").
   Qed.

--- a/theories/zoo_parabs/ws_hub_fifo.v
+++ b/theories/zoo_parabs/ws_hub_fifo.v
@@ -12,8 +12,7 @@ From zoo.language Require Import
 From zoo.diaframe Require Import
   diaframe.
 From zoo_std Require Import
-  option
-  domain.
+  option.
 From zoo_saturn Require Import
   mpmc_queue_1.
 From zoo_parabs Require Export
@@ -28,7 +27,7 @@ From zoo Require Import
 Implicit Types b closed : bool.
 Implicit Types num_active : Z.
 Implicit Types 𝑡 : location.
-Implicit Types v t until pred : val.
+Implicit Types v t notification notify pred : val.
 Implicit Types ws : list val.
 Implicit Types vs : gmultiset val.
 Implicit Types status : status.
@@ -86,7 +85,7 @@ Opaque consistent.
 Section ws_hub_fifo_G.
   Context `{ws_hub_fifo_G : WsHubFifoG Σ}.
 
-  Implicit Types P Q : iProp Σ.
+  Implicit Types P P_notification P_pred Q Q_pred : iProp Σ.
 
   Record metadata :=
     { metadata_size : nat
@@ -737,109 +736,32 @@ Section ws_hub_fifo_G.
     wp_apply+ (ws_hub_fifo_pop'𑁒spec_owner with "[$Hinv $Howner] HΦ").
   Qed.
 
-  #[local] Lemma ws_hub_fifo_steal_until₀𑁒spec P Q t ι sz pred :
-    <<<
-      ws_hub_fifo_inv t ι sz ∗
-      P ∗
-      □ (
-        P -∗
-        WP pred () {{ res,
-          ∃ b,
-          ⌜res = #b⌝ ∗
-          if b then Q else P
-        }}
-      )
-    | ∀∀ vs,
-      ws_hub_fifo_model t vs
-    >>>
-      ws_hub_fifo_steal_until₀ t pred @ ↑ι
-    <<<
-      ∃∃ o,
-      match o with
-      | None =>
-          ws_hub_fifo_model t vs
-      | Some v =>
-          ∃ vs',
-          ⌜vs = {[+v+]} ⊎ vs'⌝ ∗
-          ws_hub_fifo_model t vs'
-      end
-    | RET o;
-      if o then P else Q
-    >>>.
-  Proof.
-    iIntros "%Φ ((:inv) & HP & #Hpred) HΦ".
-
-    iLöb as "HLöb".
-
-    wp_rec.
-    wp_apply+ (wp_wand with "(Hpred HP)") as (res) "(%b & -> & H)".
-    destruct b.
-
-    - iApply fupd_wp.
-      iMod "HΦ" as "(%vs & Hmodel & _ & HΦ)".
-      iMod ("HΦ" $! None with "Hmodel") as "HΦ".
-      iSteps.
-
-    - wp_apply+ domain_yield𑁒spec.
-
-      awp_apply+ ws_hub_fifo_pop'𑁒spec; first iSteps.
-      iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
-      iAaccIntro with "Hmodel"; first iSteps. iIntros ([v |]) "Hmodel".
-
-      + iRight. iExists (Some v). iFrameSteps.
-
-      + iLeft. iFrameSteps.
-  Qed.
-  Lemma ws_hub_fifo_steal_until𑁒spec P Q t ι sz i i_ empty max_round_noyield pred :
-    i = ⁺i_ →
-    (0 ≤ max_round_noyield)%Z →
-    <<<
-      ws_hub_fifo_inv t ι sz ∗
-      ws_hub_fifo_owner t i_ Nonblocked empty ∗
-      P ∗
-      □ (
-        P -∗
-        WP pred () {{ res,
-          ∃ b,
-          ⌜res = #b⌝ ∗
-          if b then Q else P
-        }}
-      )
-    | ∀∀ vs,
-      ws_hub_fifo_model t vs
-    >>>
-      ws_hub_fifo_steal_until t #i #max_round_noyield pred @ ↑ι
-    <<<
-      ∃∃ o,
-      match o with
-      | None =>
-          ws_hub_fifo_model t vs
-      | Some v =>
-          ∃ vs',
-          ⌜vs = {[+v+]} ⊎ vs'⌝ ∗
-          ws_hub_fifo_model t vs'
-      end
-    | RET o;
-      ws_hub_fifo_owner t i_ Nonblocked empty ∗
-      if o then P else Q
-    >>>.
-  Proof.
-    iIntros (-> Hmax_round_noyield) "%Φ (#Hinv & Howner & HP & #Hpred) HΦ".
-
-    wp_rec.
-    wp_apply+ (ws_hub_fifo_steal_until₀𑁒spec P Q with "[$Hinv $HP $Hpred]").
-    iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ H".
-    iApply ("HΦ" with "[$Howner $H]").
-  Qed.
-
-  #[local] Lemma ws_hub_fifo_steal₀𑁒spec t ι (sz : nat) i :
+  #[local] Lemma ws_hub_fifo_steal_aux𑁒spec P_notification P_pred Q_pred t ι (sz : nat) i notification pred :
     (0 ≤ i < sz)%Z →
     <<<
-      ws_hub_fifo_inv t ι sz
+      ws_hub_fifo_inv t ι sz ∗
+      P_notification ∗
+      ( ∀ notify,
+        P_notification -∗
+        WP notify () {{ itype_unit }} -∗
+        WP notification notify {{ res,
+          ⌜res = ()%V⌝ ∗
+          P_notification
+        }}
+      ) ∗
+      P_pred ∗
+      □ (
+        P_pred -∗
+        WP pred () {{ res,
+          ∃ b,
+          ⌜res = #b⌝ ∗
+          if b then Q_pred else P_pred
+        }}
+      )
     | ∀∀ vs,
       ws_hub_fifo_model t vs
     >>>
-      ws_hub_fifo_steal₀ t #i @ ↑ι
+      ws_hub_fifo_steal_aux t #i notification pred @ ↑ι
     <<<
       ∃∃ o,
       match o with
@@ -851,47 +773,109 @@ Section ws_hub_fifo_G.
           ws_hub_fifo_model t vs'
       end
     | RET o;
-      True
+      P_notification ∗
+      if o then P_pred else Q_pred
     >>>.
   Proof.
-    iIntros "%Hi %Φ (:inv) HΦ".
+    iIntros "%Hi %Φ ((:inv) & HP_notification & Hnotification & HP_pred & #Hpred) HΦ".
 
-    iLöb as "HLöb".
+    iLöb as "HLöb" forall (notification).
 
     wp_rec. wp_load.
-    wp_apply+ (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as "_". 1: done.
-    wp_apply+ ws_hub_fifo_closed𑁒spec as ([]) "_". 1: iSteps.
-
-    - wp_apply+ ws_hub_fifo_notify_all𑁒spec as "_"; first iSteps.
-      wp_pures.
-
-      iMod "HΦ" as "(%vs & Hmodel & _ & HΦ)".
-      iMod ("HΦ" $! None with "Hmodel") as "HΦ".
-      iSteps.
+    wp_apply (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as "_". 1: done.
+    wp_apply+ (wp_wand with "(Hnotification HP_notification [])") as (res) "(-> & HP_notification)".
+    { wp_load.
+      wp_apply (waiters_notify𑁒spec with "Hwaiters_inv") => //.
+    }
+    wp_apply+ (wp_wand with "(Hpred HP_pred)") as (res) "(%b & -> & Hb)".
+    destruct b; wp_pures.
 
     - wp_load.
-      wp_apply+ (mpmc_queue_1_is_empty𑁒spec' with "Hqueue_inv") as (b) "_".
+      wp_apply (waiters_cancel_wait𑁒spec with "Hwaiters_inv") as (b) "_". 1: done.
 
       wp_bind (if: _ then _ else _)%E.
       wp_apply (wp_wand itype_unit) as (res) "->".
-      { destruct b; wp_pures.
-        all: wp_load.
-        1: wp_apply (waiters_commit_wait𑁒spec with "Hwaiters_inv"); first done.
-        2: wp_apply (waiters_cancel_wait𑁒spec with "Hwaiters_inv"); first done.
-        all: iSteps.
+      { destruct b; wp_pures. 1: iSteps.
+        wp_load.
+        wp_apply (waiters_notify_one𑁒spec with "Hwaiters_inv") => //.
       }
 
-      awp_apply+ ws_hub_fifo_pop'𑁒spec; first iSteps.
-      iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
-      iAaccIntro with "Hmodel"; first iSteps. iIntros ([v |]) "Hmodel".
+      iApply fupd_wp.
+      iMod "HΦ" as "(%vs & Hmodel & _ & HΦ)".
+      iMod ("HΦ" $! None with "Hmodel") as "HΦ".
+      iSteps.
 
-      + iRight. iExists (Some v). iFrameStep 5.
+    - awp_apply+ ws_hub_fifo_pop'𑁒spec. 1: iSteps.
+      iApply (aacc_aupd with "HΦ"). 1: done. iIntros "%vs Hmodel".
+      iAaccIntro with "Hmodel". 1: iSteps. iIntros ([v |]) "Hmodel".
 
-        wp_apply ws_hub_fifo_end_inactive𑁒spec. 1: iSteps.
+      + iRight. iExists (Some v). iFrame. iIntros "!> HΦ !> _".
+        wp_load.
+        wp_apply (waiters_cancel_wait𑁒spec with "Hwaiters_inv"). 1: done.
         iSteps.
 
-      + iLeft. iFrameSteps.
+      + iLeft. iFrame. iIntros "!> HΦ !> _".
+        wp_load.
+        wp_apply (waiters_commit_wait𑁒spec with "Hwaiters_inv") as "_". 1: done.
+        wp_apply+ ("HLöb" with "HP_notification [] Hb HΦ"). 1: iSteps.
   Qed.
+
+  Lemma ws_hub_fifo_steal_until𑁒spec P_notification P_pred Q_pred t ι sz i i_ empty max_round_noyield max_round_yield notification pred :
+    i = ⁺i_ →
+    (0 ≤ max_round_noyield)%Z →
+    (0 ≤ max_round_yield)%Z →
+    <<<
+      ws_hub_fifo_inv t ι sz ∗
+      ws_hub_fifo_owner t i_ Nonblocked empty ∗
+      P_notification ∗
+      ( ∀ notify,
+        P_notification -∗
+        WP notify () {{ itype_unit }} -∗
+        WP notification notify {{ res,
+          ⌜res = ()%V⌝ ∗
+          P_notification
+        }}
+      ) ∗
+      P_pred ∗
+      □ (
+        P_pred -∗
+        WP pred () {{ res,
+          ∃ b,
+          ⌜res = #b⌝ ∗
+          if b then Q_pred else P_pred
+        }}
+      )
+    | ∀∀ vs,
+      ws_hub_fifo_model t vs
+    >>>
+      ws_hub_fifo_steal_until t #i #max_round_noyield #max_round_yield notification pred @ ↑ι
+    <<<
+      ∃∃ o,
+      match o with
+      | None =>
+          ws_hub_fifo_model t vs
+      | Some v =>
+          ∃ vs',
+          ⌜vs = {[+v+]} ⊎ vs'⌝ ∗
+          ws_hub_fifo_model t vs'
+      end
+    | RET o;
+      ws_hub_fifo_owner t i_ Nonblocked empty ∗
+      P_notification ∗
+      if o then P_pred else Q_pred
+    >>>.
+  Proof.
+    iIntros (-> _ _) "%Φ (#Hinv & Howner & HP_notification & Hnotification & HP_pred & #Hpred) HΦ".
+    iDestruct (ws_hub_fifo_inv_owner with "Hinv Howner") as %Hi.
+
+    wp_rec.
+
+    wp_apply+ (ws_hub_fifo_steal_aux𑁒spec P_notification P_pred Q_pred with "[$Hinv $HP_notification $Hnotification $HP_pred $Hpred]"). 1: lia.
+    iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ H".
+
+    iApply ("HΦ" with "[$Howner $H]").
+  Qed.
+
   Lemma ws_hub_fifo_steal𑁒spec t ι sz i i_ empty max_round_noyield max_round_yield :
     i = ⁺i_ →
     (0 ≤ max_round_noyield)%Z →
@@ -917,14 +901,31 @@ Section ws_hub_fifo_G.
       ws_hub_fifo_owner t i_ (if o then Nonblocked else Blocked) empty
     >>>.
   Proof.
-    iIntros (-> Hmax_round_noyield Hmax_round_yield) "%Φ (#Hinv & Howner) HΦ".
+    iIntros (-> _ _) "%Φ (#Hinv & Howner) HΦ".
     iDestruct (ws_hub_fifo_inv_owner with "Hinv Howner") as %Hi.
 
     wp_rec.
     wp_apply+ (ws_hub_fifo_begin_inactive𑁒spec with "Hinv") as "_".
-    wp_apply+ (ws_hub_fifo_steal₀𑁒spec with "Hinv"). 1: lia.
-    iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ HP".
-    iApply ("HΦ" with "[$Howner $HP]").
+
+    wp_apply+ (ws_hub_fifo_steal_aux𑁒spec True True True with "[$Hinv]"). 1: lia.
+    { iStep. iSplit. 1: iSteps. iStep 3.
+      wp_apply+ (ws_hub_fifo_closed𑁒spec with "Hinv") as ([]) "_".
+      all: iSteps.
+    }
+    iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ _".
+
+    wp_pures.
+
+    wp_bind (Match _ _ _ _).
+    wp_apply (wp_wand itype_unit) as (res) "->".
+    { destruct o as [v |]; wp_pures.
+      - wp_apply (ws_hub_fifo_end_inactive𑁒spec with "Hinv") => //.
+      - wp_apply (ws_hub_fifo_notify_all𑁒spec with "Hinv") => //.
+    }
+
+    wp_pures.
+
+    iApply ("HΦ" with "Howner").
   Qed.
 
   Lemma ws_hub_fifo_close𑁒spec t ι sz :
@@ -948,27 +949,37 @@ End ws_hub_fifo_G.
 Section ws_hub_fifo_G.
   Context `{ws_hub_fifo_G : WsHubFifoG Σ}.
 
-  Implicit Types P Q : iProp Σ.
+  Implicit Types P P_notification P_pred Q Q_pred : iProp Σ.
 
-  Lemma ws_hub_fifo_pop_steal_until𑁒spec P Q t ι sz i i_ empty max_round_noyield pred :
+  Lemma ws_hub_fifo_pop_steal_until𑁒spec P_notification P_pred Q_pred t ι sz i i_ empty max_round_noyield max_round_yield notification pred :
     i = ⁺i_ →
     (0 ≤ max_round_noyield)%Z →
+    (0 ≤ max_round_yield)%Z →
     <<<
       ws_hub_fifo_inv t ι sz ∗
       ws_hub_fifo_owner t i_ Nonblocked empty ∗
-      P ∗
+      P_notification ∗
+      ( ∀ notify,
+        P_notification -∗
+        WP notify () {{ itype_unit }} -∗
+        WP notification notify {{ res,
+          ⌜res = ()%V⌝ ∗
+          P_notification
+        }}
+      ) ∗
+      P_pred ∗
       □ (
-        P -∗
+        P_pred -∗
         WP pred () {{ res,
           ∃ b,
           ⌜res = #b⌝ ∗
-          if b then Q else P
+          if b then Q_pred else P_pred
         }}
       )
     | ∀∀ vs,
       ws_hub_fifo_model t vs
     >>>
-      ws_hub_fifo_pop_steal_until t #i #max_round_noyield pred @ ↑ι
+      ws_hub_fifo_pop_steal_until t #i #max_round_noyield #max_round_yield notification pred @ ↑ι
     <<<
       ∃∃ o,
       match o with
@@ -982,30 +993,31 @@ Section ws_hub_fifo_G.
     | empty,
       RET o;
       ws_hub_fifo_owner t i_ Nonblocked empty ∗
-      if o then
-        P
-      else
-        ⌜empty = Empty⌝ ∗
-        Q
+      P_notification ∗
+      if o then P_pred else Q_pred
     >>>.
   Proof.
-    iIntros (->) "%Hmax_round_noyield %Φ (#Hinv & Howner & HP & #Hpred) HΦ".
+    iIntros (-> Hmax_round_noyield Hmax_round_yield) "%Φ (#Hinv & Howner & HP_notification & Hnotification & HP_pred & #Hpred) HΦ".
 
     wp_rec.
+    wp_apply+ (wp_wand with "(Hpred HP_pred)") as (res) "(%b & -> & Hb)".
+    destruct b; wp_pures.
 
-    awp_apply+ (ws_hub_fifo_pop𑁒spec with "[$Hinv $Howner]"); [done.. |].
-    iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
-    iAaccIntro with "Hmodel"; first iSteps. iIntros ([v |]) "Hmodel !>".
+    - iMod "HΦ" as "(%vs & Hmodel & _ & HΦ)".
+      iMod ("HΦ" $! None with "Hmodel") as "HΦ".
+      iSteps.
 
-    - iRight. iExists (Some v). iFrameSteps.
+    - awp_apply+ (ws_hub_fifo_pop𑁒spec with "[$Hinv $Howner]"). 1: done.
+      iApply (aacc_aupd with "HΦ"). 1: done. iIntros "%vs Hmodel".
+      iAaccIntro with "Hmodel". 1: iFrameSteps. iIntros ([v |]) "Hmodel !>".
 
-    - iLeft. iFrame.
-      iIntros "HΦ !> Howner {%- Hmax_round_noyield}".
+      + iRight. iExists (Some v). iFrameSteps.
 
-      wp_apply+ (ws_hub_fifo_steal_until𑁒spec P Q with "[$Hinv $Howner $HP $Hpred]"); [done.. |].
-      iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ (Howner & H)".
-      iApply ("HΦ" with "[- $Howner]").
-      destruct o; iFrameSteps.
+      + iLeft. iFrame. iIntros "HΦ !> Howner {%- Hmax_round_noyield Hmax_round_yield}".
+
+        wp_apply+ (ws_hub_fifo_steal_until𑁒spec P_notification P_pred Q_pred with "[$Hinv $Howner $HP_notification $Hnotification $Hb $Hpred]"). 1-3: done.
+        iApply (atomic_update_wand with "HΦ").
+        iSteps.
   Qed.
 
   Lemma ws_hub_fifo_pop_steal𑁒spec t ι sz i i_ empty max_round_noyield max_round_yield :
@@ -1049,8 +1061,7 @@ Section ws_hub_fifo_G.
     - iDestruct "Hmodel" as "(%vs' & -> & Hmodel)".
       iRight. iExists (Some v). iSteps.
 
-    - iLeft. iFrame.
-      iIntros "HΦ !> Howner {%- Hmax_round_noyield Hmax_round_yield}".
+    - iLeft. iFrame. iIntros "HΦ !> Howner {%- Hmax_round_noyield Hmax_round_yield}".
 
       wp_apply+ (ws_hub_fifo_steal𑁒spec with "[$Hinv $Howner]"); [done.. |].
       iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ Howner".

--- a/theories/zoo_parabs/ws_hub_fifo__code.v
+++ b/theories/zoo_parabs/ws_hub_fifo__code.v
@@ -16,7 +16,7 @@ From zoo Require Import
 
 Definition ws_hub_fifo_create : val :=
   fun: "sz" =>
-    { "sz", mpmc_queue_1_create (), waiters_create (), "sz" + 1 }.
+    { "sz", mpmc_queue_1_create (), waiters_create "sz", "sz" + 1 }.
 
 Definition ws_hub_fifo_size : val :=
   fun: "t" =>
@@ -46,11 +46,11 @@ Definition ws_hub_fifo_closed : val :=
 
 Definition ws_hub_fifo_notify : val :=
   fun: "t" =>
-    waiters_notify "t".{waiters}.
+    waiters_notify_one "t".{waiters}.
 
 Definition ws_hub_fifo_notify_all : val :=
   fun: "t" =>
-    waiters_notify_many "t".{waiters} (ws_hub_fifo_size "t").
+    waiters_notify_all "t".{waiters}.
 
 Definition ws_hub_fifo_push : val :=
   fun: "t" "_i" "v" =>
@@ -84,31 +84,30 @@ Definition ws_hub_fifo_steal_until : val :=
     ws_hub_fifo_steal_until₀ "t" "pred".
 
 Definition ws_hub_fifo_steal₀ : val :=
-  rec: "steal" "t" =>
-    let: "waiters" := "t".{waiters} in
-    let: "waiter" := waiters_prepare_wait "waiters" in
+  rec: "steal" "t" "i" =>
+    waiters_prepare_wait "t".{waiters} "i" ;;
     if: ws_hub_fifo_closed "t" then (
       ws_hub_fifo_notify_all "t" ;;
       §None
     ) else (
       if: mpmc_queue_1_is_empty "t".{queue} then (
-        waiters_commit_wait "waiters" "waiter"
+        waiters_commit_wait "t".{waiters} "i"
       ) else (
-        waiters_cancel_wait "waiters" "waiter"
+        waiters_cancel_wait "t".{waiters} "i"
       ) ;;
       match: ws_hub_fifo_pop' "t" with
       | Some <> as "res" =>
           ws_hub_fifo_end_inactive "t" ;;
           "res"
       | None =>
-          "steal" "t"
+          "steal" "t" "i"
       end
     ).
 
 Definition ws_hub_fifo_steal : val :=
-  fun: "t" "_i" <> <> =>
+  fun: "t" "i" <> <> =>
     ws_hub_fifo_begin_inactive "t" ;;
-    ws_hub_fifo_steal₀ "t".
+    ws_hub_fifo_steal₀ "t" "i".
 
 Definition ws_hub_fifo_close : val :=
   ws_hub_fifo_begin_inactive.

--- a/theories/zoo_parabs/ws_hub_fifo__code.v
+++ b/theories/zoo_parabs/ws_hub_fifo__code.v
@@ -7,8 +7,6 @@ From zoo_parabs Require Import
   waiters.
 From zoo_saturn Require Import
   mpmc_queue_1.
-From zoo_std Require Import
-  domain.
 From zoo_parabs Require Import
   ws_hub_fifo__types.
 From zoo Require Import
@@ -65,61 +63,71 @@ Definition ws_hub_fifo_pop : val :=
   fun: "t" "_i" =>
     ws_hub_fifo_pop' "t".
 
-Definition ws_hub_fifo_steal_until₀ : val :=
-  rec: "steal_until" "t" "pred" =>
+Definition ws_hub_fifo_steal_aux : val :=
+  rec: "steal_aux" "t" "i" "notification" "pred" =>
+    waiters_prepare_wait "t".{waiters} "i" ;;
+    "notification" (fun: <> => waiters_notify "t".{waiters} "i") ;;
     if: "pred" () then (
+      if: ~ waiters_cancel_wait "t".{waiters} "i" then (
+        waiters_notify_one "t".{waiters}
+      ) else (
+        ()
+      ) ;;
       §None
     ) else (
-      domain_yield () ;;
       match: ws_hub_fifo_pop' "t" with
       | Some <> as "res" =>
+          waiters_cancel_wait "t".{waiters} "i" ;;
           "res"
       | None =>
-          "steal_until" "t" "pred"
+          waiters_commit_wait "t".{waiters} "i" ;;
+          "steal_aux" "t" "i" (fun: <> => ()) "pred"
       end
     ).
 
 Definition ws_hub_fifo_steal_until : val :=
-  fun: "t" "_i" <> "pred" =>
-    ws_hub_fifo_steal_until₀ "t" "pred".
-
-Definition ws_hub_fifo_steal₀ : val :=
-  rec: "steal" "t" "i" =>
-    waiters_prepare_wait "t".{waiters} "i" ;;
-    if: ws_hub_fifo_closed "t" then (
-      ws_hub_fifo_notify_all "t" ;;
-      §None
-    ) else (
-      if: mpmc_queue_1_is_empty "t".{queue} then (
-        waiters_commit_wait "t".{waiters} "i"
-      ) else (
-        waiters_cancel_wait "t".{waiters} "i"
-      ) ;;
-      match: ws_hub_fifo_pop' "t" with
-      | Some <> as "res" =>
-          ws_hub_fifo_end_inactive "t" ;;
-          "res"
-      | None =>
-          "steal" "t" "i"
-      end
-    ).
+  fun: "t" "i" <> <> "notification" "pred" =>
+    ws_hub_fifo_steal_aux "t" "i" "notification" "pred".
 
 Definition ws_hub_fifo_steal : val :=
   fun: "t" "i" <> <> =>
     ws_hub_fifo_begin_inactive "t" ;;
-    ws_hub_fifo_steal₀ "t" "i".
+    let: "res" :=
+      ws_hub_fifo_steal_aux
+        "t"
+        "i"
+        (fun: <> => ())
+        (fun: <> => ws_hub_fifo_closed "t")
+    in
+    match: "res" with
+    | None =>
+        ws_hub_fifo_notify_all "t"
+    | Some <> =>
+        ws_hub_fifo_end_inactive "t"
+    end ;;
+    "res".
 
 Definition ws_hub_fifo_close : val :=
   ws_hub_fifo_begin_inactive.
 
 Definition ws_hub_fifo_pop_steal_until : val :=
-  fun: "t" "i" "max_round_noyield" "pred" =>
-    match: ws_hub_fifo_pop "t" "i" with
-    | Some <> as "res" =>
-        "res"
-    | None =>
-        ws_hub_fifo_steal_until "t" "i" "max_round_noyield" "pred"
-    end.
+  fun: "t" "i" "max_round_noyield" "max_round_yield" "notification" "pred" =>
+    if: "pred" () then (
+      §None
+    ) else (
+      match: ws_hub_fifo_pop "t" "i" with
+      | Some <> as "res" =>
+          "res"
+      | None =>
+          ws_hub_fifo_steal_until
+            "t"
+            "i"
+            "max_round_noyield"
+            "max_round_yield"
+            "notification"
+            "pred"
+      end
+    ).
 
 Definition ws_hub_fifo_pop_steal : val :=
   fun: "t" "i" "max_round_noyield" "max_round_yield" =>

--- a/theories/zoo_parabs/ws_hub_fifo__types.v
+++ b/theories/zoo_parabs/ws_hub_fifo__types.v
@@ -7,8 +7,6 @@ From zoo_parabs Require Import
   waiters.
 From zoo_saturn Require Import
   mpmc_queue_1.
-From zoo_std Require Import
-  domain.
 From zoo Require Import
   options.
 

--- a/theories/zoo_parabs/ws_hub_std.v
+++ b/theories/zoo_parabs/ws_hub_std.v
@@ -30,7 +30,7 @@ From zoo Require Import
 Implicit Types b yield closed : bool.
 Implicit Types num_active : Z.
 Implicit Types 𝑡 : location.
-Implicit Types v t pred : val.
+Implicit Types v t notification notify pred : val.
 Implicit Types vs : gmultiset val.
 Implicit Types ws us : list val.
 Implicit Types vss : list $ list val.
@@ -134,7 +134,7 @@ Opaque consistent.
 Section ws_hub_std_G.
   Context `{ws_hub_std_G : WsHubStdG Σ}.
 
-  Implicit Types P Q : iProp Σ.
+  Implicit Types P P_notification P_pred Q Q_pred : iProp Σ.
 
   Record metadata :=
     { metadata_size : nat
@@ -653,7 +653,7 @@ Section ws_hub_std_G.
     - iExists None. iFrameSteps.
   Qed.
 
-  #[local] Lemma ws_hub_std_try_steal𑁒spec P Q t ι sz i i_ empty yield max_round pred :
+  #[local] Lemma ws_hub_std_try_steal₀𑁒spec P Q t ι sz i i_ empty yield max_round pred :
     i = ⁺i_ →
     (0 ≤ max_round)%Z →
     <<<
@@ -671,7 +671,7 @@ Section ws_hub_std_G.
     | ∀∀ vs,
       ws_hub_std_model t vs
     >>>
-      ws_hub_std_try_steal t #i #yield #max_round pred @ ↑ι
+      ws_hub_std_try_steal₀ t #i #yield #max_round pred @ ↑ι
     <<<
       ∃∃ o,
       match o with
@@ -688,194 +688,39 @@ Section ws_hub_std_G.
       if o is Anything then Q else P
     >>>.
   Proof.
-    intros ->.
-    iLöb as "HLöb" forall (max_round).
+    iIntros "%Hi %Hmax_round %Φ (#Hinv & Howner & HP & #Hpred) HΦ".
 
-    iIntros "%Hmax_round %Φ ((:inv) & (:owner) & HP & #Hpred) HΦ". injection Heq as <-.
-    iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
+    iLöb as "HLöb" forall (max_round Hmax_round).
 
     wp_rec. wp_pures.
     case_bool_decide as Hcase; wp_pures.
 
     - iMod "HΦ" as "(%vss & Hmodel & _ & HΦ)".
       iApply ("HΦ" $! Nothing with "Hmodel").
-      iSteps.
+      iFrame.
 
-    - awp_apply+ (ws_hub_std_try_steal_once𑁒spec with "[Hqueues_owner Hround]"); [done | iSteps |].
-      iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
-      iAaccIntro with "Hmodel"; first iSteps. iIntros ([v |]) "Hmodel !>".
+    - awp_apply+ (ws_hub_std_try_steal_once𑁒spec with "[$Hinv $Howner]"). 1: done.
+      iApply (aacc_aupd with "HΦ"). 1: done. iIntros "%vs Hmodel".
+      iAaccIntro with "Hmodel". 1: iSteps. iIntros ([v |]) "Hmodel !>".
 
       + iRight. iExists (Something v). iFrameSteps.
 
-      + iLeft. iFrame.
-        iIntros "HΦ !> Howner {%- Hmax_round Hcase}".
+      + iLeft. iFrame. iIntros "HΦ !> Howner {%- Hmax_round Hcase}".
 
-        wp_apply+ (wp_wand with "(Hpred HP)") as (res) "(%b & -> & H)".
+        wp_apply+ (wp_wand with "(Hpred HP)") as (res) "(%b & -> & Hb)".
         destruct b; wp_pures.
 
         * iMod "HΦ" as "(%vss & Hmodel & _ & HΦ)".
-          iApply ("HΦ" $! Anything with "Hmodel [$Howner $H]").
+          iApply ("HΦ" $! Anything with "Hmodel [$Howner $Hb]").
 
         * wp_bind (if: _ then _ else _)%E.
           wp_apply (wp_wand itype_unit) as (res) "->".
           { destruct yield; iSteps. }
-          wp_apply+ ("HLöb" with "[] [$Howner $H] HΦ"); iSteps.
+
+          wp_apply+ ("HLöb" with "[%] Howner Hb HΦ"). 1: lia.
   Qed.
 
-  #[local] Lemma ws_hub_std_steal_until₀𑁒spec P Q t ι sz i i_ empty pred :
-    i = ⁺i_ →
-    <<<
-      ws_hub_std_inv t ι sz ∗
-      ws_hub_std_owner t i_ Blocked empty ∗
-      P ∗
-      □ (
-        P -∗
-        WP pred () {{ res,
-          ∃ b,
-          ⌜res = #b⌝ ∗
-          if b then Q else P
-        }}
-      )
-    | ∀∀ vs,
-      ws_hub_std_model t vs
-    >>>
-      ws_hub_std_steal_until₀ t #i pred @ ↑ι
-    <<<
-      ∃∃ o,
-      match o with
-      | None =>
-          ws_hub_std_model t vs
-      | Some v =>
-          ∃ vs',
-          ⌜vs = {[+v+]} ⊎ vs'⌝ ∗
-          ws_hub_std_model t vs'
-      end
-    | RET o;
-      ws_hub_std_owner t i_ Blocked empty ∗
-      if o then P else Q
-    >>>.
-  Proof.
-    iIntros (->) "%Φ (#Hinv & Howner & HP & #Hpred) HΦ".
-
-    iLöb as "HLöb".
-
-    wp_rec.
-
-    awp_apply+ (ws_hub_std_try_steal_once𑁒spec with "[$Hinv $Howner]"); first done.
-    iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
-    iAaccIntro with "Hmodel"; first iSteps. iIntros ([v |]) "Hmodel !>".
-
-    - iRight. iExists (Some v). iFrameSteps.
-
-    - iLeft. iFrame.
-      iIntros "HΦ !> Howner {%}".
-
-      wp_apply+ (wp_wand with "(Hpred HP)") as (res) "(%b & -> & H)".
-      destruct b; wp_pures.
-
-      + iMod "HΦ" as "(%vss & Hmodel & _ & HΦ)".
-        iApply ("HΦ" $! None with "Hmodel [$Howner $H]").
-
-      + wp_apply domain_yield𑁒spec.
-        wp_apply+ ("HLöb" with "Howner H HΦ").
-  Qed.
-  #[local] Lemma ws_hub_std_steal_until₁𑁒spec P Q t ι sz i i_ empty max_round_noyield pred :
-    i = ⁺i_ →
-    (0 ≤ max_round_noyield)%Z →
-    <<<
-      ws_hub_std_inv t ι sz ∗
-      ws_hub_std_owner t i_ Blocked empty ∗
-      P ∗
-      □ (
-        P -∗
-        WP pred () {{ res,
-          ∃ b,
-          ⌜res = #b⌝ ∗
-          if b then Q else P
-        }}
-      )
-    | ∀∀ vs,
-      ws_hub_std_model t vs
-    >>>
-      ws_hub_std_steal_until₁ t #i #max_round_noyield pred @ ↑ι
-    <<<
-      ∃∃ o,
-      match o with
-      | None =>
-          ws_hub_std_model t vs
-      | Some v =>
-          ∃ vs',
-          ⌜vs = {[+v+]} ⊎ vs'⌝ ∗
-          ws_hub_std_model t vs'
-      end
-    | RET o;
-      ws_hub_std_owner t i_ Blocked empty ∗
-      if o then P else Q
-    >>>.
-  Proof.
-    iIntros (->) "%Hmax_round_noyield %Φ (#Hinv & Howner & HP & #Hpred) HΦ".
-
-    wp_rec.
-
-    awp_apply+ (ws_hub_std_try_steal𑁒spec P Q with "[$Hinv $Howner $HP $Hpred]"); [done.. |].
-    iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
-    iAaccIntro with "Hmodel"; first iSteps. iIntros ([| | v]) "Hmodel !>".
-
-    - iLeft. iFrame.
-      iIntros "HΦ !> (Howner & HP) {%}".
-
-      wp_apply+ (ws_hub_std_steal_until₀𑁒spec P Q with "[$Hinv $Howner $HP $Hpred] HΦ"); first done.
-
-    - iRight. iExists None. iFrameSteps.
-
-    - iRight. iExists (Some v). iFrameSteps.
-  Qed.
-  Lemma ws_hub_std_steal_until𑁒spec P Q t ι sz i i_ empty max_round_noyield pred :
-    i = ⁺i_ →
-    (0 ≤ max_round_noyield)%Z →
-    <<<
-      ws_hub_std_inv t ι sz ∗
-      ws_hub_std_owner t i_ Nonblocked empty ∗
-      P ∗
-      □ (
-        P -∗
-        WP pred () {{ res,
-          ∃ b,
-          ⌜res = #b⌝ ∗
-          if b then Q else P
-        }}
-      )
-    | ∀∀ vs,
-      ws_hub_std_model t vs
-    >>>
-      ws_hub_std_steal_until t #i #max_round_noyield pred @ ↑ι
-    <<<
-      ∃∃ o,
-      match o with
-      | None =>
-          ws_hub_std_model t vs
-      | Some v =>
-          ∃ vs',
-          ⌜vs = {[+v+]} ⊎ vs'⌝ ∗
-          ws_hub_std_model t vs'
-      end
-    | RET o;
-      ws_hub_std_owner t i_ Nonblocked empty ∗
-      if o then P else Q
-    >>>.
-  Proof.
-    iIntros (->) "%Hmax_round_noyield %Φ (#Hinv & Howner & HP & #Hpred) HΦ".
-
-    wp_rec.
-    wp_apply+ (ws_hub_std_block_active𑁒spec with "[$Hinv $Howner]") as "Howner"; first done.
-    wp_apply+ (ws_hub_std_steal_until₁𑁒spec P Q with "[$Hinv $Howner $HP $Hpred]"); [done.. |].
-    iApply (atomic_update_wand with "HΦ"). iIntros "_ %o HΦ (Howner & H)".
-    wp_apply+ (ws_hub_std_unblock_active𑁒spec with "[$Hinv $Howner]") as "Howner"; first done.
-    wp_pures.
-    iApply ("HΦ" with "[$Howner $H]").
-  Qed.
-
-  #[local] Lemma ws_hub_std_steal_aux𑁒spec P Q t ι sz i i_ empty max_round_noyield max_round_yield pred :
+  #[local] Lemma ws_hub_std_try_steal𑁒spec P Q t ι sz i i_ empty max_round_noyield max_round_yield pred :
     i = ⁺i_ →
     (0 ≤ max_round_noyield)%Z →
     (0 ≤ max_round_yield)%Z →
@@ -894,7 +739,7 @@ Section ws_hub_std_G.
     | ∀∀ vs,
       ws_hub_std_model t vs
     >>>
-      ws_hub_std_steal_aux t #i #max_round_noyield #max_round_yield pred @ ↑ι
+      ws_hub_std_try_steal t #i #max_round_noyield #max_round_yield pred @ ↑ι
     <<<
       ∃∃ o,
       match o with
@@ -911,34 +756,52 @@ Section ws_hub_std_G.
       if o is Anything then Q else P
     >>>.
   Proof.
-    iIntros (->) "%Hmax_round_noyield %Hmax_round_yield %Φ (#Hinv & Howner & HP & #Hpred) HΦ".
+    iIntros (-> Hmax_round_noyield Hmax_round_yield) "%Φ (#Hinv & Howner & HP & #Hpred) HΦ".
 
     wp_rec.
 
-    awp_apply+ (ws_hub_std_try_steal𑁒spec P Q with "[$Hinv $Howner $HP $Hpred]"); [done.. |].
-    iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
-    iAaccIntro with "Hmodel"; first iSteps. iIntros ([| | v]) "Hmodel !>".
+    awp_apply+ (ws_hub_std_try_steal₀𑁒spec P Q with "[$Hinv $Howner $HP $Hpred]"). 1-2: done.
+    iApply (aacc_aupd with "HΦ"). 1: done. iIntros "%vs Hmodel".
+    iAaccIntro with "Hmodel". 1: iSteps. iIntros ([| | v]) "Hmodel !>".
 
-    - iLeft. iFrame.
-      iIntros "HΦ !> (Howner & HP) {%- Hmax_round_yield}".
+    - iLeft. iFrame. iIntros "HΦ !> (Howner & HP) {%- Hmax_round_yield}".
 
-      wp_apply+ (ws_hub_std_try_steal𑁒spec P Q with "[$Hinv $Howner $HP $Hpred] HΦ"); done.
+      wp_apply+ (ws_hub_std_try_steal₀𑁒spec P Q with "[$Hinv $Howner $HP $Hpred] HΦ"). 1-2: done.
 
     - iRight. iExists Anything. iFrameSteps.
 
     - iRight. iExists (Something v). iFrameSteps.
   Qed.
-  #[local] Lemma ws_hub_std_steal₀𑁒spec t ι sz i i_ empty max_round_noyield max_round_yield :
+
+  #[local] Lemma ws_hub_std_steal_aux𑁒spec P_notification P_pred Q_pred t ι sz i i_ empty max_round_noyield max_round_yield notification pred :
     i = ⁺i_ →
     (0 ≤ max_round_noyield)%Z →
     (0 ≤ max_round_yield)%Z →
     <<<
       ws_hub_std_inv t ι sz ∗
-      ws_hub_std_owner t i_ Blocked empty
+      ws_hub_std_owner t i_ Blocked empty ∗
+      P_notification ∗
+      ( ∀ notify,
+        P_notification -∗
+        WP notify () {{ itype_unit }} -∗
+        WP notification notify {{ res,
+          ⌜res = ()%V⌝ ∗
+          P_notification
+        }}
+      ) ∗
+      P_pred ∗
+      □ (
+        P_pred -∗
+        WP pred () {{ res,
+          ∃ b,
+          ⌜res = #b⌝ ∗
+          if b then Q_pred else P_pred
+        }}
+      )
     | ∀∀ vs,
       ws_hub_std_model t vs
     >>>
-      ws_hub_std_steal₀ t #i #max_round_noyield #max_round_yield @ ↑ι
+      ws_hub_std_steal_aux t #i #max_round_noyield #max_round_yield notification pred @ ↑ι
     <<<
       ∃∃ o,
       match o with
@@ -950,26 +813,23 @@ Section ws_hub_std_G.
           ws_hub_std_model t vs'
       end
     | RET o;
-      ws_hub_std_owner t i_ (if o then Nonblocked else Blocked) empty
+      ws_hub_std_owner t i_ (if o then Nonblocked else Blocked) empty ∗
+      P_notification ∗
+      if o then P_pred else Q_pred
     >>>.
   Proof.
-    iIntros (->) "%Hmax_round_noyield %Hmax_round_yield %Φ (#Hinv & Howner) HΦ".
+    iIntros (->) "%Hmax_round_noyield %Hmax_round_yield %Φ (#Hinv & Howner & HP_notification & Hnotification & HP_pred & #Hpred) HΦ".
     iDestruct (ws_hub_std_inv_owner with "Hinv Howner") as %Hi.
 
-    iLöb as "HLöb".
+    iLöb as "HLöb" forall (notification).
 
     wp_rec.
 
-    awp_apply+ (ws_hub_std_steal_aux𑁒spec True True with "[$Hinv $Howner]"); [done.. | |].
-    { iStep 3.
-      wp_apply+ (ws_hub_std_closed𑁒spec with "Hinv") as (closed) "_".
-      iSteps. destruct closed; iSteps.
-    }
-    iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
-    iAaccIntro with "Hmodel"; first iSteps. iIntros ([| | v]) "Hmodel !>".
+    awp_apply+ (ws_hub_std_try_steal𑁒spec P_pred Q_pred with "[$Hinv $Howner $HP_pred $Hpred]"). 1-3: done.
+    iApply (aacc_aupd with "HΦ"). 1: done. iIntros "%vs Hmodel".
+    iAaccIntro with "Hmodel". 1: iFrameSteps. iIntros ([| | v]) "Hmodel !>".
 
-    - iLeft. iFrame.
-      iIntros "HΦ !> (Howner & _) {%- Hi}".
+    - iLeft. iFrame. iIntros "HΦ !> (Howner & HP_pred) {%- Hi}".
 
       iDestruct "Hinv" as "(:inv)".
 
@@ -977,8 +837,8 @@ Section ws_hub_std_G.
       wp_apply (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as "_". 1: lia.
 
       awp_apply+ (ws_hub_std_try_steal_once𑁒spec with "[$Howner]"). 1: done. 1: iSteps.
-      iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
-      iAaccIntro with "Hmodel"; first iSteps. iIntros ([v |]) "Hmodel !>".
+      iApply (aacc_aupd with "HΦ"). 1: done. iIntros "%vs Hmodel".
+      iAaccIntro with "Hmodel". 1: iFrameSteps. iIntros ([v |]) "Hmodel !>".
 
       + iDestruct "Hmodel" as "(%vs' & -> & Hmodel)".
         iRight. iExists (Some v).
@@ -986,40 +846,115 @@ Section ws_hub_std_G.
         iIntros "HΦ !> Howner {%- Hi}".
 
         wp_load.
-        wp_apply (waiters_cancel_wait𑁒spec with "Hwaiters_inv") as "_". 1: lia.
-        wp_apply+ (ws_hub_std_unblock𑁒spec with "[$Howner]") as "Howner". 1: done. 1: iSteps.
+        wp_apply (waiters_cancel_wait𑁒spec with "Hwaiters_inv") as (b) "_". 1: lia.
         wp_pures.
-        iApply ("HΦ" with "Howner").
 
-      + iLeft. iFrame.
-        iIntros "HΦ !> Howner {%- Hi}".
+        iApply ("HΦ" with "[$]").
 
-        wp_apply+ ws_hub_std_closed𑁒spec as ([]) "_". 1: iSteps.
+      + iLeft. iFrame. iIntros "HΦ !> Howner {%- Hi}".
 
-        * wp_apply+ ws_hub_std_notify_all𑁒spec as "_". 1: iSteps.
+        wp_apply+ (wp_wand with "(Hnotification HP_notification [])") as (res) "(-> & HP_notification)".
+        { wp_load.
+          wp_apply (waiters_notify𑁒spec with "Hwaiters_inv") => //. 1: lia.
+        }
+        wp_apply+ (wp_wand with "(Hpred HP_pred)") as (res) "(%b & -> & Hb)".
+        destruct b; wp_pures.
+
+        * wp_load.
+          wp_apply (waiters_cancel_wait𑁒spec with "Hwaiters_inv") as (b) "_". 1: lia.
+
+          wp_bind (if: _ then _ else _)%E.
+          wp_apply (wp_wand itype_unit) as (res) "->".
+          { destruct b; wp_pures. 1: iSteps.
+            wp_load.
+            wp_apply (waiters_notify_one𑁒spec with "Hwaiters_inv") => //.
+          }
+
           wp_pures.
-          iMod "HΦ" as "(%vss & Hmodel & _ & HΦ)".
-          iApply ("HΦ" $! None with "Hmodel Howner").
+
+          iMod "HΦ" as "(%vs & Hmodel & _ & HΦ)".
+          iMod ("HΦ" $! None with "Hmodel") as "HΦ".
+          iApply ("HΦ" with "[$]").
 
         * wp_load.
           wp_apply (waiters_commit_wait𑁒spec with "Hwaiters_inv") as "_". 1: lia.
-          wp_apply+ ("HLöb" with "Howner HΦ").
+          wp_apply+ ("HLöb" with "Howner HP_notification [] Hb HΦ"). 1: iSteps.
 
-    - iRight. iExists None. iFrame. iIntros "HΦ !> (Howner & _)".
-
-      wp_apply+ (ws_hub_std_notify_all𑁒spec with "Hinv") as "_".
-      wp_pures.
-      iApply ("HΦ" with "Howner").
-
-    - iDestruct "Hmodel" as "(%vs' & -> & Hmodel)".
-      iRight. iExists (Some v).
+    - iRight. iExists None.
       iSplitL "Hmodel". { iFrameSteps. }
-      iIntros "HΦ !> (Howner & _)".
+      iIntros "HΦ !> (Howner & HQ_pred)".
 
-      wp_apply+ (ws_hub_std_unblock𑁒spec with "[$Hinv $Howner]") as "Howner". 1: done.
       wp_pures.
-      iApply ("HΦ" with "Howner").
+
+      iApply ("HΦ" with "[$]").
+
+    - iRight. iExists (Some v).
+      iSplitL "Hmodel". { iFrameSteps. }
+      iIntros "HΦ !> (Howner & HP_pred)".
+
+      wp_pures.
+
+      iApply ("HΦ" with "[$]").
   Qed.
+
+  Lemma ws_hub_std_steal_until𑁒spec P_notification P_pred Q_pred t ι sz i i_ empty max_round_noyield max_round_yield notification pred :
+    i = ⁺i_ →
+    (0 ≤ max_round_noyield)%Z →
+    (0 ≤ max_round_yield)%Z →
+    <<<
+      ws_hub_std_inv t ι sz ∗
+      ws_hub_std_owner t i_ Nonblocked empty ∗
+      P_notification ∗
+      ( ∀ notify,
+        P_notification -∗
+        WP notify () {{ itype_unit }} -∗
+        WP notification notify {{ res,
+          ⌜res = ()%V⌝ ∗
+          P_notification
+        }}
+      ) ∗
+      P_pred ∗
+      □ (
+        P_pred -∗
+        WP pred () {{ res,
+          ∃ b,
+          ⌜res = #b⌝ ∗
+          if b then Q_pred else P_pred
+        }}
+      )
+    | ∀∀ vs,
+      ws_hub_std_model t vs
+    >>>
+      ws_hub_std_steal_until t #i #max_round_noyield #max_round_yield notification pred @ ↑ι
+    <<<
+      ∃∃ o,
+      match o with
+      | None =>
+          ws_hub_std_model t vs
+      | Some v =>
+          ∃ vs',
+          ⌜vs = {[+v+]} ⊎ vs'⌝ ∗
+          ws_hub_std_model t vs'
+      end
+    | RET o;
+      ws_hub_std_owner t i_ Nonblocked empty ∗
+      P_notification ∗
+      if o then P_pred else Q_pred
+    >>>.
+  Proof.
+    iIntros (-> Hmax_round_noyield Hmax_round_yield) "%Φ (#Hinv & Howner & HP_notification & Hnotification & HP_pred & #Hpred) HΦ".
+    iDestruct (ws_hub_std_inv_owner with "Hinv Howner") as %Hi.
+
+    wp_rec.
+    wp_apply+ (ws_hub_std_block_active𑁒spec with "[$Hinv $Howner]") as "Howner". 1: done.
+
+    wp_apply+ (ws_hub_std_steal_aux𑁒spec P_notification P_pred Q_pred with "[$Hinv $Howner $HP_notification $Hnotification $HP_pred $Hpred]"). 1-3: done.
+    iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ (Howner & HP_notification & H)".
+
+    wp_apply+ (ws_hub_std_unblock_active𑁒spec with "[$Hinv $Howner]"). 1: done.
+    iSteps.
+  Qed.
+
   Lemma ws_hub_std_steal𑁒spec t ι sz i i_ empty max_round_noyield max_round_yield :
     i = ⁺i_ →
     (0 ≤ max_round_noyield)%Z →
@@ -1045,11 +980,35 @@ Section ws_hub_std_G.
       ws_hub_std_owner t i_ (if o then Nonblocked else Blocked) empty
     >>>.
   Proof.
-    iIntros (->) "%Hmax_round_noyield %Hmax_round_yield %Φ (#Hinv & Howner) HΦ".
+    iIntros (-> Hmax_round_noyield Hmax_round_yield) "%Φ (#Hinv & Howner) HΦ".
+    iDestruct (ws_hub_std_inv_owner with "Hinv Howner") as %Hi.
 
     wp_rec.
-    wp_apply+ (ws_hub_std_block𑁒spec with "[$Hinv $Howner]") as "Howner"; first done.
-    wp_apply+ (ws_hub_std_steal₀𑁒spec with "[$Hinv $Howner] HΦ"). all: done.
+    wp_apply+ (ws_hub_std_block𑁒spec with "[$Hinv $Howner]") as "Howner". 1: done.
+
+    wp_apply+ (ws_hub_std_steal_aux𑁒spec True True True with "[$Hinv $Howner]"). 1-3: done.
+    { iStep. iSplit. 1: iSteps. iStep 3.
+      wp_apply+ (ws_hub_std_closed𑁒spec with "Hinv") as ([]) "_".
+      all: iSteps.
+    }
+    iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ (Howner & _)".
+
+    wp_pures.
+
+    wp_bind (Match _ _ _ _).
+    wp_apply (wp_wand (λ res,
+      ⌜res = ()%V⌝ ∗
+      ws_hub_std_owner t i_ (if o then Nonblocked else Blocked) empty
+    )%I with "[Howner]") as (res) "(-> & Howner)".
+    { destruct o as [v |]; wp_pures.
+      - wp_apply (ws_hub_std_unblock𑁒spec with "[$Hinv $Howner]") as "$" => //.
+      - wp_apply (ws_hub_std_notify_all𑁒spec with "Hinv").
+        iFrameSteps.
+    }
+
+    wp_pures.
+
+    iApply ("HΦ" with "Howner").
   Qed.
 
   Lemma ws_hub_std_close𑁒spec t ι sz :
@@ -1073,27 +1032,37 @@ End ws_hub_std_G.
 Section ws_hub_std_G.
   Context `{ws_hub_std_G : WsHubStdG Σ}.
 
-  Implicit Types P Q : iProp Σ.
+  Implicit Types P P_notification P_pred Q Q_pred : iProp Σ.
 
-  Lemma ws_hub_std_pop_steal_until𑁒spec P Q t ι sz i i_ empty max_round_noyield pred :
+  Lemma ws_hub_std_pop_steal_until𑁒spec P_notification P_pred Q_pred t ι sz i i_ empty max_round_noyield max_round_yield notification pred :
     i = ⁺i_ →
     (0 ≤ max_round_noyield)%Z →
+    (0 ≤ max_round_yield)%Z →
     <<<
       ws_hub_std_inv t ι sz ∗
       ws_hub_std_owner t i_ Nonblocked empty ∗
-      P ∗
+      P_notification ∗
+      ( ∀ notify,
+        P_notification -∗
+        WP notify () {{ itype_unit }} -∗
+        WP notification notify {{ res,
+          ⌜res = ()%V⌝ ∗
+          P_notification
+        }}
+      ) ∗
+      P_pred ∗
       □ (
-        P -∗
+        P_pred -∗
         WP pred () {{ res,
           ∃ b,
           ⌜res = #b⌝ ∗
-          if b then Q else P
+          if b then Q_pred else P_pred
         }}
       )
     | ∀∀ vs,
       ws_hub_std_model t vs
     >>>
-      ws_hub_std_pop_steal_until t #i #max_round_noyield pred @ ↑ι
+      ws_hub_std_pop_steal_until t #i #max_round_noyield #max_round_yield notification pred @ ↑ι
     <<<
       ∃∃ o,
       match o with
@@ -1107,30 +1076,31 @@ Section ws_hub_std_G.
     | empty,
       RET o;
       ws_hub_std_owner t i_ Nonblocked empty ∗
-      if o then
-        P
-      else
-        ⌜empty = Empty⌝ ∗
-        Q
+      P_notification ∗
+      if o then P_pred else Q_pred
     >>>.
   Proof.
-    iIntros (->) "%Hmax_round_noyield %Φ (#Hinv & Howner & HP & #Hpred) HΦ".
+    iIntros (-> Hmax_round_noyield Hmax_round_yield) "%Φ (#Hinv & Howner & HP_notification & Hnotification & HP_pred & #Hpred) HΦ".
 
     wp_rec.
+    wp_apply+ (wp_wand with "(Hpred HP_pred)") as (res) "(%b & -> & Hb)".
+    destruct b; wp_pures.
 
-    awp_apply+ (ws_hub_std_pop𑁒spec with "[$Hinv $Howner]"); [done.. |].
-    iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
-    iAaccIntro with "Hmodel"; first iSteps. iIntros ([v |]) "Hmodel !>".
+    - iMod "HΦ" as "(%vs & Hmodel & _ & HΦ)".
+      iMod ("HΦ" $! None with "Hmodel") as "HΦ".
+      iSteps.
 
-    - iRight. iExists (Some v). iFrameSteps.
+    - awp_apply+ (ws_hub_std_pop𑁒spec with "[$Hinv $Howner]"). 1: done.
+      iApply (aacc_aupd with "HΦ"). 1: done. iIntros "%vs Hmodel".
+      iAaccIntro with "Hmodel". 1: iFrameSteps. iIntros ([v |]) "Hmodel !>".
 
-    - iLeft. iFrame.
-      iIntros "HΦ !> Howner {%- Hmax_round_noyield}".
+      + iRight. iExists (Some v). iFrameSteps.
 
-      wp_apply+ (ws_hub_std_steal_until𑁒spec P Q with "[$Hinv $Howner $HP $Hpred]"); [done.. |].
-      iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ (Howner & H)".
-      iApply ("HΦ" with "[- $Howner]").
-      destruct o; iFrameSteps.
+      + iLeft. iFrame. iIntros "HΦ !> Howner {%- Hmax_round_noyield Hmax_round_yield}".
+
+        wp_apply+ (ws_hub_std_steal_until𑁒spec P_notification P_pred Q_pred with "[$Hinv $Howner $HP_notification $Hnotification $Hb $Hpred]"). 1-3: done.
+        iApply (atomic_update_wand with "HΦ").
+        iSteps.
   Qed.
 
   Lemma ws_hub_std_pop_steal𑁒spec t ι sz i i_ empty max_round_noyield max_round_yield :
@@ -1174,8 +1144,7 @@ Section ws_hub_std_G.
     - iDestruct "Hmodel" as "(%vs' & -> & Hmodel)".
       iRight. iExists (Some v). iSteps.
 
-    - iLeft. iFrame.
-      iIntros "HΦ !> Howner {%- Hmax_round_noyield Hmax_round_yield}".
+    - iLeft. iFrame. iIntros "HΦ !> Howner {%- Hmax_round_noyield Hmax_round_yield}".
 
       wp_apply+ (ws_hub_std_steal𑁒spec with "[$Hinv $Howner]"); [done.. |].
       iApply (atomic_update_wand with "HΦ"). iIntros "%vs %o HΦ Howner".

--- a/theories/zoo_parabs/ws_hub_std.v
+++ b/theories/zoo_parabs/ws_hub_std.v
@@ -29,7 +29,7 @@ From zoo Require Import
 
 Implicit Types b yield closed : bool.
 Implicit Types num_active : Z.
-Implicit Types l : location.
+Implicit Types 𝑡 : location.
 Implicit Types v t pred : val.
 Implicit Types vs : gmultiset val.
 Implicit Types ws us : list val.
@@ -155,35 +155,35 @@ Section ws_hub_std_G.
     solve_countable.
   Qed.
 
-  #[local] Definition inv_inner l : iProp Σ :=
+  #[local] Definition inv_inner 𝑡 : iProp Σ :=
     ∃ num_active,
-    l.[num_active] ↦ #num_active.
+    𝑡.[num_active] ↦ #num_active.
   #[local] Instance : CustomIpat "inv_inner" :=
     " ( %num_active
-      & Hl_num_active
+      & H𝑡_num_active
       )
     ".
   Definition ws_hub_std_inv t ι sz : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     ⌜sz = γ.(metadata_size)⌝ ∗
-    l.[queues] ↦□ γ.(metadata_queues) ∗
-    l.[rounds] ↦□ γ.(metadata_rounds) ∗
-    l.[waiters] ↦□ γ.(metadata_waiters) ∗
+    𝑡.[queues] ↦□ γ.(metadata_queues) ∗
+    𝑡.[rounds] ↦□ γ.(metadata_rounds) ∗
+    𝑡.[waiters] ↦□ γ.(metadata_waiters) ∗
     ws_deques_public_inv γ.(metadata_queues) ι γ.(metadata_size) ∗
     array_inv γ.(metadata_rounds) γ.(metadata_size) ∗
-    waiters_inv γ.(metadata_waiters) ∗
-    inv nroot (inv_inner l).
+    waiters_inv γ.(metadata_waiters) sz ∗
+    inv nroot (inv_inner 𝑡).
   #[local] Instance : CustomIpat "inv" :=
-    " ( %l{}
+    " ( %𝑡{}
       & %γ{}
       & {%Heq{};->}
       & #Hmeta{}
       & ->
-      & #Hl{}_queues
-      & #Hl{}_rounds
-      & #Hl{}_waiters
+      & #H𝑡{}_queues
+      & #H𝑡{}_rounds
+      & #H𝑡{}_waiters
       & #Hqueues{}_inv
       & #Hrounds{}_inv
       & #Hwaiters{}_inv
@@ -192,13 +192,13 @@ Section ws_hub_std_G.
     ".
 
   Definition ws_hub_std_model t vs : iProp Σ :=
-    ∃ l γ vss,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ vss,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     ws_deques_public_model γ.(metadata_queues) vss ∗
     ⌜consistent vs vss⌝.
   #[local] Instance : CustomIpat "model" :=
-    " ( %l_
+    " ( %𝑡_
       & %γ_
       & %vss
       & %Heq
@@ -209,15 +209,15 @@ Section ws_hub_std_G.
     ".
 
   Definition ws_hub_std_owner t i status empty : iProp Σ :=
-    ∃ l γ ws round n,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ ws round n,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     ws_deques_public_owner γ.(metadata_queues) i status ws ∗
     ⌜empty = Empty → ws = []⌝ ∗
     array_slice γ.(metadata_rounds) i DfracDiscarded [round] ∗
     random_round_model' round (γ.(metadata_size) - 1) n.
   #[local] Instance : CustomIpat "owner" :=
-    " ( %l{;_}
+    " ( %𝑡{;_}
       & %γ{;_}
       & %ws{}
       & %round{}
@@ -263,6 +263,16 @@ Section ws_hub_std_G.
     iApply (ws_deques_public_owner_exclusive with "Hqueues_owner1 Hqueues_owner2").
   Qed.
 
+  Lemma ws_hub_std_inv_owner t ι sz i status empty :
+    ws_hub_std_inv t ι sz -∗
+    ws_hub_std_owner t i status empty -∗
+    ⌜i < sz⌝.
+  Proof.
+    iIntros "(:inv) (:owner)". simplify.
+    iDestruct (meta_agree with "Hmeta Hmeta_") as %<-.
+    iApply (ws_deques_public_inv_owner with "Hqueues_inv Hqueues_owner").
+  Qed.
+
   Lemma ws_hub_std_model_empty t ι sz vs :
     ws_hub_std_inv t ι sz -∗
     ws_hub_std_model t vs -∗
@@ -304,7 +314,7 @@ Section ws_hub_std_G.
 
     wp_rec.
 
-    wp_apply+ (waiters_create𑁒spec with "[//]") as (waiters) "#Hwaiters_inv".
+    wp_apply+ (waiters_create𑁒spec with "[//]") as (waiters) "#Hwaiters_inv". 1: done.
 
     wp_apply+ (array_unsafe_init𑁒spec_disentangled (λ _ round, random_round_model' round (₊sz - 1) (₊sz - 1))) as (v_rounds rounds) "(%Hrounds & Hrounds_model & Hrounds)"; first done.
     { iIntros "!> %i %Hi".
@@ -318,10 +328,10 @@ Section ws_hub_std_G.
 
     wp_apply+ (ws_deques_public_create𑁒spec with "[//]") as (queues) "(#Hqueues_inv & Hqueues_model & Hqueues_owner)"; first done.
 
-    wp_block l as "Hmeta" "(Hl_queues & Hl_rounds & Hl_waiters & Hl_num_active & _)".
-    iMod (pointsto_persist with "Hl_queues") as "#Hl_queues".
-    iMod (pointsto_persist with "Hl_rounds") as "#Hl_rounds".
-    iMod (pointsto_persist with "Hl_waiters") as "#Hl_waiters".
+    wp_block 𝑡 as "Hmeta" "(H𝑡_queues & H𝑡_rounds & H𝑡_waiters & H𝑡_num_active & _)".
+    iMod (pointsto_persist with "H𝑡_queues") as "#H𝑡_queues".
+    iMod (pointsto_persist with "H𝑡_rounds") as "#H𝑡_rounds".
+    iMod (pointsto_persist with "H𝑡_waiters") as "#H𝑡_waiters".
 
     pose γ := {|
       metadata_size := ₊sz ;
@@ -333,7 +343,7 @@ Section ws_hub_std_G.
     iMod (meta_set γ with "Hmeta") as "#Hmeta"; first done.
 
     iApply "HΦ".
-    iSplitL "Hl_num_active"; iSteps.
+    iSplitL "H𝑡_num_active"; iSteps.
     - iPureIntro. apply consistent_alloc.
     - iMod (array_model_persist with "Hrounds_model") as "Hrounds_model".
       iDestruct (array_model_atomize with "Hrounds_model") as "(_ & Hrounds_model)".
@@ -493,7 +503,7 @@ Section ws_hub_std_G.
     iIntros "%Φ (:inv) HΦ".
 
     wp_rec. wp_load.
-    wp_apply (waiters_notify𑁒spec with "Hwaiters_inv HΦ").
+    wp_apply (waiters_notify_one𑁒spec with "Hwaiters_inv HΦ").
   Qed.
 
   #[local] Lemma ws_hub_std_notify_all𑁒spec t ι sz :
@@ -508,10 +518,8 @@ Section ws_hub_std_G.
   Proof.
     iIntros "%Φ (:inv) HΦ".
 
-    wp_rec.
-    wp_apply (ws_hub_std_size𑁒spec) as "_"; first iSteps.
-    wp_load.
-    wp_apply (waiters_notify_many𑁒spec with "Hwaiters_inv HΦ"); first lia.
+    wp_rec. wp_load.
+    wp_apply (waiters_notify_all𑁒spec with "Hwaiters_inv HΦ").
   Qed.
 
   Lemma ws_hub_std_push𑁒spec t ι sz i i_ empty v :
@@ -946,6 +954,7 @@ Section ws_hub_std_G.
     >>>.
   Proof.
     iIntros (->) "%Hmax_round_noyield %Hmax_round_yield %Φ (#Hinv & Howner) HΦ".
+    iDestruct (ws_hub_std_inv_owner with "Hinv Howner") as %Hi.
 
     iLöb as "HLöb".
 
@@ -960,38 +969,40 @@ Section ws_hub_std_G.
     iAaccIntro with "Hmodel"; first iSteps. iIntros ([| | v]) "Hmodel !>".
 
     - iLeft. iFrame.
-      iIntros "HΦ !> (Howner & _) {%}".
+      iIntros "HΦ !> (Howner & _) {%- Hi}".
 
       iDestruct "Hinv" as "(:inv)".
 
       wp_load.
-      wp_apply+ (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as (waiter) "Hwaiter".
+      wp_apply (waiters_prepare_wait𑁒spec with "Hwaiters_inv") as "_". 1: lia.
 
-      awp_apply+ (ws_hub_std_try_steal_once𑁒spec with "[$Howner]") without "Hwaiter"; [done.. | iSteps |].
+      awp_apply+ (ws_hub_std_try_steal_once𑁒spec with "[$Howner]"). 1: done. 1: iSteps.
       iApply (aacc_aupd with "HΦ"); first done. iIntros "%vs Hmodel".
       iAaccIntro with "Hmodel"; first iSteps. iIntros ([v |]) "Hmodel !>".
 
       + iDestruct "Hmodel" as "(%vs' & -> & Hmodel)".
         iRight. iExists (Some v).
         iSplitL "Hmodel". { iFrameSteps. }
-        iIntros "HΦ !> Howner Hwaiter {%}".
+        iIntros "HΦ !> Howner {%- Hi}".
 
-        wp_apply+ (waiters_cancel_wait𑁒spec with "[$Hwaiters_inv $Hwaiter]") as "_".
+        wp_load.
+        wp_apply (waiters_cancel_wait𑁒spec with "Hwaiters_inv") as "_". 1: lia.
         wp_apply+ (ws_hub_std_unblock𑁒spec with "[$Howner]") as "Howner". 1: done. 1: iSteps.
         wp_pures.
         iApply ("HΦ" with "Howner").
 
       + iLeft. iFrame.
-        iIntros "HΦ !> Howner Hwaiter {%}".
+        iIntros "HΦ !> Howner {%- Hi}".
 
-        wp_apply+ ws_hub_std_closed𑁒spec as ([]) "_"; first iSteps.
+        wp_apply+ ws_hub_std_closed𑁒spec as ([]) "_". 1: iSteps.
 
         * wp_apply+ ws_hub_std_notify_all𑁒spec as "_". 1: iSteps.
           wp_pures.
           iMod "HΦ" as "(%vss & Hmodel & _ & HΦ)".
           iApply ("HΦ" $! None with "Hmodel Howner").
 
-        * wp_apply+ (waiters_commit_wait𑁒spec with "[$Hwaiters_inv $Hwaiter]") as "_".
+        * wp_load.
+          wp_apply (waiters_commit_wait𑁒spec with "Hwaiters_inv") as "_". 1: lia.
           wp_apply+ ("HLöb" with "Howner HΦ").
 
     - iRight. iExists None. iFrame. iIntros "HΦ !> (Howner & _)".

--- a/theories/zoo_parabs/ws_hub_std__code.v
+++ b/theories/zoo_parabs/ws_hub_std__code.v
@@ -86,7 +86,7 @@ Definition ws_hub_std_try_steal_once : val :=
     random_round_reset "round" ;;
     ws_deques_public_steal_as "t".{queues} "i" "round".
 
-Definition ws_hub_std_try_steal : val :=
+Definition ws_hub_std_try_steal₀ : val :=
   rec: "try_steal" "t" "i" "yield" "max_round" "pred" =>
     if: "max_round" ≤ 0 then (
       §Nothing
@@ -108,101 +108,117 @@ Definition ws_hub_std_try_steal : val :=
       end
     ).
 
-Definition ws_hub_std_steal_until₀ : val :=
-  rec: "steal_until" "t" "i" "pred" =>
-    match: ws_hub_std_try_steal_once "t" "i" with
-    | Some <> as "res" =>
-        "res"
-    | None =>
-        if: "pred" () then (
-          §None
-        ) else (
-          domain_yield () ;;
-          "steal_until" "t" "i" "pred"
-        )
-    end.
-
-Definition ws_hub_std_steal_until₁ : val :=
-  fun: "t" "i" "max_round_noyield" "pred" =>
-    match: ws_hub_std_try_steal "t" "i" false "max_round_noyield" "pred" with
-    | Something "v" =>
-        ‘Some( "v" )
-    | Anything =>
-        §None
-    | Nothing =>
-        ws_hub_std_steal_until₀ "t" "i" "pred"
-    end.
-
-Definition ws_hub_std_steal_until : val :=
-  fun: "t" "i" "max_round_noyield" "pred" =>
-    ws_hub_std_block_active "t" "i" ;;
-    let: "res" :=
-      ws_hub_std_steal_until₁ "t" "i" "max_round_noyield" "pred"
-    in
-    ws_hub_std_unblock_active "t" "i" ;;
-    "res".
-
-Definition ws_hub_std_steal_aux : val :=
+Definition ws_hub_std_try_steal : val :=
   fun: "t" "i" "max_round_noyield" "max_round_yield" "pred" =>
-    match: ws_hub_std_try_steal "t" "i" false "max_round_noyield" "pred" with
+    match:
+      ws_hub_std_try_steal₀ "t" "i" false "max_round_noyield" "pred"
+    with
     | Something <> as "res" =>
         "res"
     | Anything =>
         §Anything
     | Nothing =>
-        ws_hub_std_try_steal "t" "i" true "max_round_yield" "pred"
+        ws_hub_std_try_steal₀ "t" "i" true "max_round_yield" "pred"
     end.
 
-Definition ws_hub_std_steal₀ : val :=
-  rec: "steal" "t" "i" "max_round_noyield" "max_round_yield" =>
+Definition ws_hub_std_steal_aux : val :=
+  rec: "steal_aux" "t" "i" "max_round_noyield" "max_round_yield" "notification" "pred" =>
     match:
-      ws_hub_std_steal_aux
+      ws_hub_std_try_steal
         "t"
         "i"
         "max_round_noyield"
         "max_round_yield"
-        (fun: <> => ws_hub_std_closed "t")
+        "pred"
     with
     | Something "v" =>
-        ws_hub_std_unblock "t" "i" ;;
         ‘Some( "v" )
     | Anything =>
-        ws_hub_std_notify_all "t" ;;
         §None
     | Nothing =>
         waiters_prepare_wait "t".{waiters} "i" ;;
         match: ws_hub_std_try_steal_once "t" "i" with
         | Some <> as "res" =>
             waiters_cancel_wait "t".{waiters} "i" ;;
-            ws_hub_std_unblock "t" "i" ;;
             "res"
         | None =>
-            if: ws_hub_std_closed "t" then (
-              ws_hub_std_notify_all "t" ;;
+            "notification" (fun: <> => waiters_notify "t".{waiters} "i") ;;
+            if: "pred" () then (
+              if: ~ waiters_cancel_wait "t".{waiters} "i" then (
+                waiters_notify_one "t".{waiters}
+              ) else (
+                ()
+              ) ;;
               §None
             ) else (
               waiters_commit_wait "t".{waiters} "i" ;;
-              "steal" "t" "i" "max_round_noyield" "max_round_yield"
+              "steal_aux"
+                "t"
+                "i"
+                "max_round_noyield"
+                "max_round_yield"
+                (fun: <> => ())
+                "pred"
             )
         end
     end.
 
+Definition ws_hub_std_steal_until : val :=
+  fun: "t" "i" "max_round_noyield" "max_round_yield" "notification" "pred" =>
+    ws_hub_std_block_active "t" "i" ;;
+    let: "res" :=
+      ws_hub_std_steal_aux
+        "t"
+        "i"
+        "max_round_noyield"
+        "max_round_yield"
+        "notification"
+        "pred"
+    in
+    ws_hub_std_unblock_active "t" "i" ;;
+    "res".
+
 Definition ws_hub_std_steal : val :=
   fun: "t" "i" "max_round_noyield" "max_round_yield" =>
     ws_hub_std_block "t" "i" ;;
-    ws_hub_std_steal₀ "t" "i" "max_round_noyield" "max_round_yield".
+    let: "res" :=
+      ws_hub_std_steal_aux
+        "t"
+        "i"
+        "max_round_noyield"
+        "max_round_yield"
+        (fun: <> => ())
+        (fun: <> => ws_hub_std_closed "t")
+    in
+    match: "res" with
+    | None =>
+        ws_hub_std_notify_all "t"
+    | Some <> =>
+        ws_hub_std_unblock "t" "i"
+    end ;;
+    "res".
 
 Definition ws_hub_std_close : val :=
   ws_hub_std_begin_inactive.
 
 Definition ws_hub_std_pop_steal_until : val :=
-  fun: "t" "i" "max_round_noyield" "pred" =>
-    match: ws_hub_std_pop "t" "i" with
-    | Some <> as "res" =>
-        "res"
-    | None =>
-        ws_hub_std_steal_until "t" "i" "max_round_noyield" "pred"
-    end.
+  fun: "t" "i" "max_round_noyield" "max_round_yield" "notification" "pred" =>
+    if: "pred" () then (
+      §None
+    ) else (
+      match: ws_hub_std_pop "t" "i" with
+      | Some <> as "res" =>
+          "res"
+      | None =>
+          ws_hub_std_steal_until
+            "t"
+            "i"
+            "max_round_noyield"
+            "max_round_yield"
+            "notification"
+            "pred"
+      end
+    ).
 
 Definition ws_hub_std_pop_steal : val :=
   fun: "t" "i" "max_round_noyield" "max_round_yield" =>

--- a/theories/zoo_parabs/ws_hub_std__code.v
+++ b/theories/zoo_parabs/ws_hub_std__code.v
@@ -23,7 +23,7 @@ Definition ws_hub_std_create : val :=
       array_unsafe_init
         "sz"
         (fun: <> => random_round_create (int_positive_part ("sz" - 1))),
-      waiters_create (),
+      waiters_create "sz",
       "sz" + 1
     }.
 
@@ -65,11 +65,11 @@ Definition ws_hub_std_closed : val :=
 
 Definition ws_hub_std_notify : val :=
   fun: "t" =>
-    waiters_notify "t".{waiters}.
+    waiters_notify_one "t".{waiters}.
 
 Definition ws_hub_std_notify_all : val :=
   fun: "t" =>
-    waiters_notify_many "t".{waiters} (ws_hub_std_size "t").
+    waiters_notify_all "t".{waiters}.
 
 Definition ws_hub_std_push : val :=
   fun: "t" "i" "v" =>
@@ -170,11 +170,10 @@ Definition ws_hub_std_steal₀ : val :=
         ws_hub_std_notify_all "t" ;;
         §None
     | Nothing =>
-        let: "waiters" := "t".{waiters} in
-        let: "waiter" := waiters_prepare_wait "waiters" in
+        waiters_prepare_wait "t".{waiters} "i" ;;
         match: ws_hub_std_try_steal_once "t" "i" with
         | Some <> as "res" =>
-            waiters_cancel_wait "waiters" "waiter" ;;
+            waiters_cancel_wait "t".{waiters} "i" ;;
             ws_hub_std_unblock "t" "i" ;;
             "res"
         | None =>
@@ -182,7 +181,7 @@ Definition ws_hub_std_steal₀ : val :=
               ws_hub_std_notify_all "t" ;;
               §None
             ) else (
-              waiters_commit_wait "waiters" "waiter" ;;
+              waiters_commit_wait "t".{waiters} "i" ;;
               "steal" "t" "i" "max_round_noyield" "max_round_yield"
             )
         end

--- a/theories/zoo_std/ivar_3.v
+++ b/theories/zoo_std/ivar_3.v
@@ -23,7 +23,7 @@ From zoo Require Import
   options.
 
 Implicit Types b : bool.
-Implicit Types v waiter : val.
+Implicit Types v waiter ctx : val.
 Implicit Types waiters : list val.
 Implicit Types own : ownership.
 
@@ -881,6 +881,43 @@ Module base.
       iSplitR "Hwaiters HΦ". { iExists (Set_ v). iSteps. }
       iSteps.
     Qed.
+
+    Lemma ivar_3_notify𑁒spec P t γ Ψ Ξ Ω ctx :
+      {{{
+        ivar_3_inv t γ Ψ Ξ Ω ∗
+        ivar_3_producer γ ∗
+        ▷ Ψ ()%V ∗
+        ▷ □ Ξ ()%V ∗
+        P ∗
+        □ (
+          ∀ waiter ω,
+          P -∗
+          Ω #t waiter ω -∗
+          WP waiter ctx () {{ res,
+            ⌜res = ()%V⌝ ∗
+            P
+          }}
+        )
+      }}}
+        ivar_3_notify #t ctx
+      {{{
+        RET ();
+        ivar_3_result γ () ∗
+        P
+      }}}.
+    Proof.
+      iIntros "%Φ (#Hinv & Hproducer & HΨ & HΞ & HP & #H) HΦ".
+
+      wp_rec.
+      wp_apply+ (ivar_3_set𑁒spec with "[$Hinv $Hproducer $HΨ $HΞ]") as (waiters ωs) "(#Hresult & #Hwaiters & HΩs)".
+
+      wp_apply+ (lst_iter𑁒spec' (λ _ _, P) with "[$HP HΩs]"). 1: done.
+      { iDestruct (big_sepL2_retract_r with "HΩs") as "(_ & HΩs)".
+        iApply (big_sepL_impl with "HΩs").
+        iSteps.
+      }
+      iSteps.
+    Qed.
   End ivar_3_G.
 
   #[global] Opaque ivar_3_inv.
@@ -1406,6 +1443,37 @@ Section ivar_3_G.
     iDestruct (meta_agree with "Hmeta_1 Hmeta_2") as %->. iClear "Hmeta_1".
 
     wp_apply (base.ivar_3_set𑁒spec _ _ Ψ with "[$]").
+    iSteps.
+  Qed.
+
+  Lemma ivar_3_notify𑁒spec P t Ψ Ξ Ω ctx :
+    {{{
+      ivar_3_inv t Ψ Ξ Ω ∗
+      ivar_3_producer t ∗
+      ▷ Ψ ()%V ∗
+      ▷ □ Ξ ()%V ∗
+      P ∗
+      □ (
+        ∀ waiter ω,
+        P -∗
+        Ω t waiter ω -∗
+        WP waiter ctx () {{ res,
+          ⌜res = ()%V⌝ ∗
+          P
+        }}
+      )
+    }}}
+      ivar_3_notify t ctx
+    {{{
+      RET ();
+      ivar_3_result t () ∗
+      P
+    }}}.
+  Proof.
+    iIntros "%Φ ((:inv =1) & (:producer =2) & HΨ & HΞ & HP & H) HΦ". simplify.
+    iDestruct (meta_agree with "Hmeta_1 Hmeta_2") as %->. iClear "Hmeta_1".
+
+    wp_apply (base.ivar_3_notify𑁒spec P with "[$Hinv_1 $Hproducer_2 $HΨ $HΞ $HP $H]").
     iSteps.
   Qed.
 End ivar_3_G.

--- a/theories/zoo_std/ivar_3__code.v
+++ b/theories/zoo_std/ivar_3__code.v
@@ -4,6 +4,8 @@ From zoo.language Require Import
   typeclasses
   notations.
 From zoo_std Require Import
+  lst.
+From zoo_std Require Import
   ivar_3__types.
 From zoo Require Import
   options.
@@ -70,3 +72,8 @@ Definition ivar_3_set : val :=
     | Unset "waiters" =>
         "waiters"
     end.
+
+Definition ivar_3_notify : val :=
+  fun: "t" "ctx" =>
+    let: "waiters" := ivar_3_set "t" () in
+    lst_iter (fun: "waiter" => "waiter" "ctx" ()) "waiters".

--- a/theories/zoo_std/ivar_3__opaque.v
+++ b/theories/zoo_std/ivar_3__opaque.v
@@ -9,3 +9,4 @@ From zoo_std Require Import
 #[global] Opaque ivar_3_get.
 #[global] Opaque ivar_3_wait.
 #[global] Opaque ivar_3_set.
+#[global] Opaque ivar_3_notify.

--- a/theories/zoo_std/ivar_3__types.v
+++ b/theories/zoo_std/ivar_3__types.v
@@ -3,6 +3,8 @@ From zoo Require Import
 From zoo.language Require Import
   typeclasses
   notations.
+From zoo_std Require Import
+  lst.
 From zoo Require Import
   options.
 

--- a/theories/zoo_std/mpsc_waiter.v
+++ b/theories/zoo_std/mpsc_waiter.v
@@ -19,7 +19,7 @@ From zoo Require Import
   options.
 
 Implicit Types b : bool.
-Implicit Types l : location.
+Implicit Types 𝑡 : location.
 
 Class MpscWaiterG Σ `{zoo_G : !ZooG Σ} :=
   { #[local] mpsc_waiter_G_mutex_G :: MutexG Σ
@@ -58,34 +58,34 @@ Section mpsc_waiter_G.
     solve_countable.
   Qed.
 
-  #[local] Definition inv_inner l γ P : iProp Σ :=
+  #[local] Definition inv_inner 𝑡 γ P : iProp Σ :=
     ∃ b,
-    l.[flag] ↦ #b ∗
+    𝑡.[flag] ↦ #b ∗
     if b then
       oneshot_shot γ.(metadata_lstate) () ∗
       (P ∨ excl γ.(metadata_consumer) ())
     else
       oneshot_pending γ.(metadata_lstate) (DfracOwn 1) ().
   Definition mpsc_waiter_inv t P : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
-    l.[mutex] ↦□ γ.(metadata_mutex) ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
+    𝑡.[mutex] ↦□ γ.(metadata_mutex) ∗
     mutex_inv γ.(metadata_mutex) True ∗
-    l.[condition] ↦□ γ.(metadata_condition) ∗
+    𝑡.[condition] ↦□ γ.(metadata_condition) ∗
     condition_inv γ.(metadata_condition) ∗
-    inv nroot (inv_inner l γ P).
+    inv nroot (inv_inner 𝑡 γ P).
 
   Definition mpsc_waiter_consumer t : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     excl γ.(metadata_consumer) ().
 
   Definition mpsc_waiter_notified t : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     oneshot_shot γ.(metadata_lstate) ().
 
   #[global] Instance mpsc_waiter_inv_contractive t :
@@ -131,7 +131,7 @@ Section mpsc_waiter_G.
     mpsc_waiter_consumer t -∗
     False.
   Proof.
-    iIntros "(%l & %γ & -> & #Hmeta & Hconsumer1) (%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer2)". injection Heq as <-.
+    iIntros "(%𝑡 & %γ & -> & #Hmeta & Hconsumer1) (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer2)". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
     iApply (excl_exclusive with "Hconsumer1 Hconsumer2").
   Qed.
@@ -153,9 +153,9 @@ Section mpsc_waiter_G.
     wp_rec.
     wp_apply+ (condition_create𑁒spec with "[//]") as "%cond #Hcondition_inv".
     wp_apply+ (mutex_create𑁒spec True with "[//]") as "%mtx #Hmutex_inv".
-    wp_block l as "Hmeta" "(Hl_mutex & Hl_condition & Hl_flag & _)".
-    iMod (pointsto_persist with "Hl_mutex") as "Hl_mutex".
-    iMod (pointsto_persist with "Hl_condition") as "Hl_condition".
+    wp_block 𝑡 as "Hmeta" "(H𝑡_mutex & H𝑡_condition & H𝑡_flag & _)".
+    iMod (pointsto_persist with "H𝑡_mutex") as "H𝑡_mutex".
+    iMod (pointsto_persist with "H𝑡_condition") as "H𝑡_condition".
 
     iMod (oneshot_alloc ()) as "(%γ_lstate & Hpending)".
 
@@ -184,16 +184,15 @@ Section mpsc_waiter_G.
       mpsc_waiter_notified t
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & HP) HΦ".
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & HP) HΦ".
 
-    wp_rec.
-    wp_pures.
+    wp_rec. wp_pures.
 
     wp_bind (_.{flag})%E.
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; first iSteps.
-    iSplitR "HP HΦ"; first iSteps.
+    iSplitR "HP HΦ". { iFrameSteps. }
     iModIntro.
 
     wp_load.
@@ -207,16 +206,16 @@ Section mpsc_waiter_G.
     wp_pures.
 
     wp_bind (_.{flag})%E.
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; first iSteps.
-    iSplitR "HP Hmutex_locked"; first iSteps.
+    iSplitR "HP Hmutex_locked". { iFrameSteps. }
     iModIntro.
 
     wp_pures.
 
     wp_bind (_ <-{flag} _)%E.
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_store.
     destruct b; first iSteps.
     iMod (oneshot_update_shot with "Hb") as "#Hshot".
@@ -238,13 +237,12 @@ Section mpsc_waiter_G.
         mpsc_waiter_consumer t
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & (%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer)) HΦ". injection Heq as <-.
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer)) HΦ". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
 
-    wp_rec.
-    wp_pures.
+    wp_rec. wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last iSteps.
     iDestruct "Hb" as "(Hshot & [HP | Hconsumer'])"; last first.
@@ -263,14 +261,13 @@ Section mpsc_waiter_G.
       P
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & (%l_1 & %γ_1 & %Heq1 & Hmeta_1 & Hconsumer) & (%l_2 & %γ_2 & %Heq2 & Hmeta_2 & #Hshot)) HΦ". injection Heq1 as <-. injection Heq2 as <-.
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & (%𝑡1 & %γ1 & %Heq1 & Hmeta_1 & Hconsumer) & (%𝑡2 & %γ2 & %Heq2 & Hmeta_2 & #Hshot)) HΦ". injection Heq1 as <-. injection Heq2 as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_1") as %<-. iClear "Hmeta_1".
     iDestruct (meta_agree with "Hmeta Hmeta_2") as %<-. iClear "Hmeta_2".
 
-    wp_rec.
-    wp_pures.
+    wp_rec. wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last first.
     { iDestruct (oneshot_pending_shot with "Hb Hshot") as %[]. }
@@ -295,8 +292,8 @@ Section mpsc_waiter_G.
     wp_rec.
     wp_apply (mpsc_waiter_try_wait𑁒spec with "[$Hinv $Hconsumer]") as ([]) "Hconsumer"; first iSteps.
 
-    iDestruct "Hinv" as "(%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv)".
-    iDestruct "Hconsumer" as "(%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer)". injection Heq as <-.
+    iDestruct "Hinv" as "(%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv)".
+    iDestruct "Hconsumer" as "(%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer)". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
 
     do 2 wp_load.
@@ -317,7 +314,7 @@ Section mpsc_waiter_G.
     iIntros "!> Hmutex_locked _ Hconsumer".
     wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last iSteps.
     iDestruct "Hb" as "(Hshot & [HP | Hconsumer'])"; last first.

--- a/theories/zoo_std/spsc_waiter.v
+++ b/theories/zoo_std/spsc_waiter.v
@@ -19,7 +19,7 @@ From zoo Require Import
   options.
 
 Implicit Types b : bool.
-Implicit Types l : location.
+Implicit Types 𝑡 : location.
 
 Class SpscWaiterG Σ `{zoo_G : !ZooG Σ} :=
   { #[local] spsc_waiter_G_mutex_G :: MutexG Σ
@@ -58,40 +58,40 @@ Section spsc_waiter_G.
     solve_countable.
   Qed.
 
-  #[local] Definition inv_inner l γ P : iProp Σ :=
+  #[local] Definition inv_inner 𝑡 γ P : iProp Σ :=
     ∃ b,
-    l.[flag] ↦ #b ∗
+    𝑡.[flag] ↦ #b ∗
     if b then
       oneshot_shot γ.(metadata_lstate) () ∗
       (P ∨ excl γ.(metadata_consumer) ())
     else
       oneshot_pending γ.(metadata_lstate) (DfracOwn (1/3)) ().
   Definition spsc_waiter_inv t P : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
-    l.[mutex] ↦□ γ.(metadata_mutex) ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
+    𝑡.[mutex] ↦□ γ.(metadata_mutex) ∗
     mutex_inv γ.(metadata_mutex) True ∗
-    l.[condition] ↦□ γ.(metadata_condition) ∗
+    𝑡.[condition] ↦□ γ.(metadata_condition) ∗
     condition_inv γ.(metadata_condition) ∗
-    inv nroot (inv_inner l γ P).
+    inv nroot (inv_inner 𝑡 γ P).
 
   Definition spsc_waiter_producer t : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     oneshot_pending γ.(metadata_lstate) (DfracOwn (2/3)) ().
 
   Definition spsc_waiter_consumer t : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     excl γ.(metadata_consumer) ().
 
   Definition spsc_waiter_notified t : iProp Σ :=
-    ∃ l γ,
-    ⌜t = #l⌝ ∗
-    meta l nroot γ ∗
+    ∃ 𝑡 γ,
+    ⌜t = #𝑡⌝ ∗
+    meta 𝑡 nroot γ ∗
     oneshot_shot γ.(metadata_lstate) ().
 
   #[global] Instance spsc_waiter_inv_contractive t :
@@ -142,7 +142,7 @@ Section spsc_waiter_G.
     spsc_waiter_producer t -∗
     False.
   Proof.
-    iIntros "(%l & %γ & -> & #Hmeta & Hpending1) (%l_ & %γ_ & %Heq & Hmeta_ & Hpending2)". injection Heq as <-.
+    iIntros "(%𝑡 & %γ & -> & #Hmeta & Hpending1) (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hpending2)". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
     iDestruct (oneshot_pending_valid_2 with "Hpending1 Hpending2") as %(? & _). done.
   Qed.
@@ -152,7 +152,7 @@ Section spsc_waiter_G.
     spsc_waiter_consumer t -∗
     False.
   Proof.
-    iIntros "(%l & %γ & -> & #Hmeta & Hconsumer1) (%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer2)". injection Heq as <-.
+    iIntros "(%𝑡 & %γ & -> & #Hmeta & Hconsumer1) (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer2)". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
     iApply (excl_exclusive with "Hconsumer1 Hconsumer2").
   Qed.
@@ -175,9 +175,9 @@ Section spsc_waiter_G.
     wp_rec.
     wp_apply+ (condition_create𑁒spec with "[//]") as "%cond #Hcondition_inv".
     wp_apply+ (mutex_create𑁒spec True with "[//]") as "%mtx #Hmutex_inv".
-    wp_block l as "Hmeta" "(Hl_mutex & Hl_condition & Hl_flag & _)".
-    iMod (pointsto_persist with "Hl_mutex") as "Hl_mutex".
-    iMod (pointsto_persist with "Hl_condition") as "Hl_condition".
+    wp_block 𝑡 as "Hmeta" "(H𝑡_mutex & H𝑡_condition & H𝑡_flag & _)".
+    iMod (pointsto_persist with "H𝑡_mutex") as "H𝑡_mutex".
+    iMod (pointsto_persist with "H𝑡_condition") as "H𝑡_condition".
 
     iMod (oneshot_alloc ()) as "(%γ_lstate & Hpending)".
     iEval (assert (1 = 2/3 + 1/3)%Qp as -> by compute_done) in "Hpending".
@@ -208,7 +208,7 @@ Section spsc_waiter_G.
       spsc_waiter_notified t
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & (%l_ & %γ_ & %Heq & Hmeta_ & Hpending) & HP) HΦ". injection Heq as <-.
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hpending) & HP) HΦ". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
 
     wp_rec. wp_load.
@@ -219,7 +219,7 @@ Section spsc_waiter_G.
     { iIntros "Hmutex_locked _".
       wp_pures.
       wp_bind (_ <-{flag} _)%E.
-      iInv "Hinv" as "(%b & Hl_flag & Hb)".
+      iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
       wp_store.
       destruct b.
       { iDestruct "Hb" as "(Hshot & _)".
@@ -250,13 +250,12 @@ Section spsc_waiter_G.
         spsc_waiter_consumer t
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & (%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer)) HΦ". injection Heq as <-.
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & (%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer)) HΦ". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
 
-    wp_rec.
-    wp_pures.
+    wp_rec. wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last iSteps.
     iDestruct "Hb" as "(Hshot & [HP | Hconsumer'])"; last first.
@@ -275,14 +274,13 @@ Section spsc_waiter_G.
       P
     }}}.
   Proof.
-    iIntros "%Φ ((%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv) & (%l_1 & %γ_1 & %Heq1 & Hmeta_1 & Hconsumer) & (%l_2 & %γ_2 & %Heq2 & Hmeta_2 & #Hshot)) HΦ". injection Heq1 as <-. injection Heq2 as <-.
+    iIntros "%Φ ((%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv) & (%𝑡1 & %γ1 & %Heq1 & Hmeta_1 & Hconsumer) & (%𝑡2 & %γ2 & %Heq2 & Hmeta_2 & #Hshot)) HΦ". injection Heq1 as <-. injection Heq2 as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_1") as %<-. iClear "Hmeta_1".
     iDestruct (meta_agree with "Hmeta Hmeta_2") as %<-. iClear "Hmeta_2".
 
-    wp_rec.
-    wp_pures.
+    wp_rec. wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last first.
     { iDestruct (oneshot_pending_shot with "Hb Hshot") as %[]. }
@@ -307,8 +305,8 @@ Section spsc_waiter_G.
     wp_rec.
     wp_apply (spsc_waiter_try_wait𑁒spec with "[$Hinv $Hconsumer]") as ([]) "Hconsumer"; first iSteps.
 
-    iDestruct "Hinv" as "(%l & %γ & -> & #Hmeta & #Hl_mutex & #Hmutex_inv & #Hl_condition & #Hcondition_inv & #Hinv)".
-    iDestruct "Hconsumer" as "(%l_ & %γ_ & %Heq & Hmeta_ & Hconsumer)". injection Heq as <-.
+    iDestruct "Hinv" as "(%𝑡 & %γ & -> & #Hmeta & #H𝑡_mutex & #Hmutex_inv & #H𝑡_condition & #Hcondition_inv & #Hinv)".
+    iDestruct "Hconsumer" as "(%𝑡_ & %γ_ & %Heq & Hmeta_ & Hconsumer)". injection Heq as <-.
     iDestruct (meta_agree with "Hmeta Hmeta_") as %<-. iClear "Hmeta_".
 
     do 2 wp_load.
@@ -329,7 +327,7 @@ Section spsc_waiter_G.
     iIntros "!> Hmutex_locked _ Hconsumer".
     wp_pures.
 
-    iInv "Hinv" as "(%b & Hl_flag & Hb)".
+    iInv "Hinv" as "(%b & H𝑡_flag & Hb)".
     wp_load.
     destruct b; last iSteps.
     iDestruct "Hb" as "(Hshot & [HP | Hconsumer'])"; last first.


### PR DESCRIPTION
This PR is the second part of my reimplementation of https://github.com/clef-men/zoo/pull/14 by @gasche, following https://github.com/clef-men/zoo/pull/17.

In short, it frees `Parabs` from busy waiting, especially in `Ws_hub.steal_until`, `Pool.wait_until` and `Future.wait`.