### PR TITLE
Refine allocation semantics to prevent location aliasing

### DIFF
--- a/theories/zoo/language/semantics.v
+++ b/theories/zoo/language/semantics.v
@@ -245,7 +245,8 @@ Inductive base_step tid : expr → state → list observation → expr → state
       σ.(state_headers) !! l = None →
       ( ∀ i,
         i < ₊n →
-        σ.(state_heap) !! (l +ₗ i) = None
+          σ.(state_headers) !! (l +ₗ i) = None ∧
+          σ.(state_heap) !! (l +ₗ i) = None
       ) →
       base_step
         tid
@@ -261,7 +262,8 @@ Inductive base_step tid : expr → state → list observation → expr → state
       σ.(state_headers) !! l = None →
       ( ∀ i,
         i < length es →
-        σ.(state_heap) !! (l +ₗ i) = None
+          σ.(state_headers) !! (l +ₗ i) = None ∧
+          σ.(state_heap) !! (l +ₗ i) = None
       ) →
       base_step
         tid
@@ -500,10 +502,13 @@ Proof.
   intros l Hn.
   pose proof (location_fresh_fresh (dom σ.(state_headers) ∪ dom σ.(state_heap))) as Hfresh.
   setoid_rewrite not_elem_of_union in Hfresh.
-  apply base_step_alloc; first done.
-  all: intros; apply not_elem_of_dom.
-  1: rewrite -(location_add_0 l).
-  all: apply Hfresh; lia.
+  apply base_step_alloc. 1: done.
+  { rewrite -(location_add_0 l) //.
+    apply not_elem_of_dom, Hfresh. 1: lia.
+  } {
+    intros i Hi. split.
+    all: apply not_elem_of_dom, Hfresh; lia.
+  }
 Qed.
 Lemma base_step_block_mutable' tid tag es vs σ :
   let l := location_fresh (dom σ.(state_headers) ∪ dom σ.(state_heap)) in
@@ -521,10 +526,13 @@ Proof.
   intros l Hn ->.
   pose proof (location_fresh_fresh (dom σ.(state_headers) ∪ dom σ.(state_heap))) as Hfresh.
   setoid_rewrite not_elem_of_union in Hfresh.
-  apply base_step_block_mutable; [done.. | |].
-  all: intros; apply not_elem_of_dom.
-  - rewrite -(location_add_0 l). naive_solver.
-  - apply Hfresh. lia.
+  apply base_step_block_mutable. 1,2: done.
+  { rewrite -(location_add_0 l) //.
+    apply not_elem_of_dom, Hfresh. 1: lia.
+  } {
+    intros i Hi. split.
+    all: apply not_elem_of_dom, Hfresh; lia.
+  }
 Qed.
 Lemma base_step_block_immutable_generative_strong' tid tag es vs σ :
   es = of_vals vs →

--- a/theories/zoo/program_logic/wp.v
+++ b/theories/zoo/program_logic/wp.v
@@ -604,8 +604,7 @@ Section zoo_G.
     iApply bwp_lift_atomic_base_step_nofork; first done. iIntros "%ns %nt %σ1 %κs Hinterp !>".
     iSplit; first auto with zoo. iIntros "%κ %κs' %e2 %σ2 %es -> %Hstep _ !> !>".
     invert_base_step.
-    iMod (state_interp_alloc _ _ (replicate ₊n ()%V) with "Hinterp") as "(Hinterp & Hheader & Hmeta & Hl)".
-    all: simpl_length.
+    iMod (state_interp_alloc _ _ (replicate ₊n ()%V) with "Hinterp") as "(Hinterp & Hheader & Hmeta & Hl)". all: simpl_length. 1: naive_solver.
     iFrameSteps.
   Qed.
 
@@ -629,8 +628,7 @@ Section zoo_G.
     iApply bwp_lift_atomic_base_step_nofork; first done. iIntros "%ns %nt %σ1 %κs Hinterp !>".
     iSplit; first auto with zoo. iIntros "%κ %κs' %e2 %σ2 %es -> %Hstep _ !> !>".
     invert_base_step.
-    iMod (state_interp_alloc with "Hinterp") as "(Hinterp & Hheader & Hmeta & Hl)".
-    all: simpl_length in *.
+    iMod (state_interp_alloc with "Hinterp") as "(Hinterp & Hheader & Hmeta & Hl)". all: simpl_length in *. 1: naive_solver.
     iFrameSteps.
   Qed.
 


### PR DESCRIPTION
This PR makes the allocation semantics more precise in order to prevent location aliasing. More precisely, the freshness conditions in `base_step_alloc` and `base_step_block_mutable` are strengthened to make sure that block headers and block fields do not overlap, including zero-sized blocks.

Both the problem and the fix were suggested by @nobrakal.

### Example

To illustrate the problem, @nobrakal proposed the following example and explanation:

```rocq
Definition progr : expr :=
  let: "x" := Alloc 0 0 in
  let: "y" := Alloc 1 2 in
  "y".{1}.
```

`x` is allocated with size `0`, so `x` reserves a header at some `lx` but adds nothing to `dom heap`. The freshness precondition of the second allocation requires `ly +ₗ i ∉ dom heap` for `i < 2` only; `dom headers` is not consulted for cells. So the allocator is free to pick `ly = lx - 1`, in which case `ly +ₗ 1 = lx`, i.e. the second cell of `y` sits at the same physical address as the header of `x`.

Operationally, the program is well-behaved: `state_headers` and `state_heap` are disjoint maps, every primitive consults only one of them, and `y.{1}` simply reads `heap [ly +ₗ 1] = ValUnit`. No primitive on its own crosses the boundary between the two maps, so the aliasing is invisible at the program level.