### PR TITLE
Reinforce freshness condition on alloc

### DIFF
--- a/theories/zoo/language/state.v
+++ b/theories/zoo/language/state.v
@@ -153,6 +153,7 @@ Definition state_alloc l hdr vs σ :=
 
 Definition state_alloc_condition l sz σ :=
   σ.(state_headers) !! l = None ∧
+  σ.(state_heap) !! l = None ∧
     ∀ i,
     i < sz →
       σ.(state_headers) !! (l +ₗ i) = None ∧
@@ -169,7 +170,9 @@ Lemma state_alloc_condition_fresh sz σ :
 Proof.
   pose proof (location_fresh_fresh $ state_fresh_dom σ) as Hfresh.
   repeat setoid_rewrite not_elem_of_union in Hfresh.
-  split.
+  split_and!.
+  - rewrite /state_fresh -(location_add_0 (location_fresh _)) //.
+    apply not_elem_of_dom, Hfresh => //.
   - rewrite /state_fresh -(location_add_0 (location_fresh _)) //.
     apply not_elem_of_dom, Hfresh => //.
   - intros i Hi.


### PR DESCRIPTION
This PR follows #19 , and ensures that an allocation uses a truly-fresh name. Before this PR, a code could do:
```
Definition progr : expr :=
  let: "x" := Alloc 2 0 in
  let: "y" := Alloc 0 0 in
  "x".{1}.
```
And, because freshness in the header map was not checked against the domain of the heap for 0-sized blocks, the header of `y` could pick the second cell of `x`, creating an alias. Again, this is safe aliasing (ie, not observable by the code), but removing it would help working on the meta-theory of zoo. 